### PR TITLE
support wildcard status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Support allOf definition (#11)
+* Support wildcard status code (#12)
 
 ## 0.1.5 (2018-12-23)
 * First release for production usage

--- a/lib/openapi_parser/request_operation.rb
+++ b/lib/openapi_parser/request_operation.rb
@@ -46,6 +46,7 @@ class OpenAPIParser::RequestOperation
     operation_object&.validate_request_body(content_type, params, options)
   end
 
+  # @param [Integer] status_code
   def validate_response_body(status_code, content_type, data)
     operation_object&.validate_response_body(status_code, content_type, data)
   end

--- a/lib/openapi_parser/schemas/operation.rb
+++ b/lib/openapi_parser/schemas/operation.rb
@@ -21,6 +21,7 @@ module OpenAPIParser::Schemas
       request_body&.validate_request_body(content_type, params, options)
     end
 
+    # @param [Integer] status_code
     def validate_response_body(status_code, content_type, data)
       responses&.validate_response_body(status_code, content_type, data)
     end

--- a/lib/openapi_parser/schemas/responses.rb
+++ b/lib/openapi_parser/schemas/responses.rb
@@ -13,17 +13,30 @@ module OpenAPIParser::Schemas
     # validate params data by definition
     # find response object by status_code and content_type
     # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#patterned-fields-1
-    # @param [String] status_code
+    # @param [Integer] status_code
     # @param [String] content_type
     # @param [Hash] params
     def validate_response_body(status_code, content_type, params)
-      # TODO: support wildcard status code like 2XX
       return nil unless response
 
       res = response[status_code.to_s]
       return res.validate_parameter(content_type, params) if res
 
+      wild_card = status_code_to_wild_card(status_code)
+      res = response[wild_card]
+      return res.validate_parameter(content_type, params) if res
+
       default&.validate_parameter(content_type, params)
     end
+
+    private
+
+      # parse 400 -> 4xx
+      # OpenAPI3 allow 1xx, 2xx, 3xx... only, don't allow 41x
+      # @param [Integer] status_code
+      def status_code_to_wild_card(status_code)
+        top = status_code / 100
+        "#{top}XX"
+      end
   end
 end

--- a/spec/data/petstore-expanded.yaml
+++ b/spec/data/petstore-expanded.yaml
@@ -84,6 +84,28 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pet'
+        '4XX':
+          description: error response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+        '404':
+          description: 404 response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
         default:
           description: unexpected error
           content:

--- a/spec/openapi_parser/schemas/responses_spec.rb
+++ b/spec/openapi_parser/schemas/responses_spec.rb
@@ -37,5 +37,54 @@ RSpec.describe OpenAPIParser::Schemas::Responses do
 
       it { expect(subject).to eq([{ 'id' => 1, 'name' => 'name' }]) }
     end
+
+    context '4XX' do
+      let(:status_code) { 400 }
+
+      context 'correct' do
+        let(:params) { { 'message' => 'error' } }
+
+        it { expect(subject).to eq({ 'message' => 'error' }) }
+      end
+
+      context 'invalid (200 response)' do
+        let(:params) { [{ 'id' => 1, 'name' => 'name' }] }
+
+        it { expect { subject }.to raise_error(OpenAPIParser::ValidateError) }
+      end
+    end
+
+    context '404 (prefer use 4xx)' do
+      let(:status_code) { 404 }
+
+      context 'correct' do
+        let(:params) { { 'id' => 1 } }
+
+        it { expect(subject).to eq({ 'id' => 1 }) }
+      end
+
+      context 'invalid (4xx response)' do
+        let(:params) { { 'message' => 'error' } }
+
+        it { expect { subject }.to raise_error(OpenAPIParser::NotExistRequiredKey) }
+      end
+    end
+
+    context 'invalid status code use default' do
+      context 'bigger' do
+        let(:status_code) { 1400 }
+        let(:params) { { 'message' => 'error' } }
+
+        it { expect { subject }.to raise_error(OpenAPIParser::NotExistRequiredKey) }
+      end
+
+      context 'smaller' do
+        let(:status_code) { 40 }
+
+        let(:params) { { 'message' => 'error' } }
+
+        it { expect { subject }.to raise_error(OpenAPIParser::NotExistRequiredKey) }
+      end
+    end
   end
 end


### PR DESCRIPTION
OpenAPI3 allow 4XX status code, when we check 404 status code and not exist in definition, we can use 4XX definition.  
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#patterned-fields-1