### PR TITLE
validate_header_parameter support case incentive

### DIFF
--- a/lib/openapi_parser/concerns/parameter_validatable.rb
+++ b/lib/openapi_parser/concerns/parameter_validatable.rb
@@ -26,7 +26,7 @@ module OpenAPIParser::ParameterValidatable
     # @param [String] object_reference
     # @param [OpenAPIParser::SchemaValidator::Options] options request validator options
     def validate_header_parameter(headers, object_reference, options)
-      OpenAPIParser::ParameterValidator.validate_parameter(header_parameter_hash, headers, object_reference, options)
+      OpenAPIParser::ParameterValidator.validate_parameter(header_parameter_hash, headers, object_reference, options, true)
     end
 
     def header_parameter_hash

--- a/lib/openapi_parser/parameter_validator.rb
+++ b/lib/openapi_parser/parameter_validator.rb
@@ -4,12 +4,16 @@ class OpenAPIParser::ParameterValidator
     # @param [Hash] params
     # @param [String] object_reference
     # @param [OpenAPIParser::SchemaValidator::Options] options
-    def validate_parameter(parameters_hash, params, object_reference, options)
+    # @param [Boolean] is_header is header or not (ignore params key case)
+    def validate_parameter(parameters_hash, params, object_reference, options, is_header = false)
       no_exist_required_key = []
+
+      params_key_converted = params.keys.map { |k| [(is_header ? k&.downcase : k), k] }.to_h
       parameters_hash.each do |k, v|
-        if params.include?(k)
-          coerced = v.validate_params(params[k], options)
-          params[k] = coerced if options.coerce_value
+        key = params_key_converted[k.downcase]
+        if params.include?(key)
+          coerced = v.validate_params(params[key], options)
+          params[key] = coerced if options.coerce_value
         elsif v.required
           no_exist_required_key << k
         end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -746,7 +746,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
     end
 
     context 'valid header' do
-      let(:headers) { { 'token' => 1, 'header_2' => 'h' } }
+      let(:headers) { { 'TOKEN' => 1, 'header_2' => 'h' } }
 
       it { expect(subject).not_to eq nil }
 


### PR DESCRIPTION
Header names are case-insensitive in RFC.

> 3.2.  Header Fields
>    Each header field consists of a case-insensitive field name followed
>    by a colon (":"), optional leading whitespace, the field value, and
>    optional trailing whitespace.
> 
> https://tools.ietf.org/html/rfc7230#section-3.2

bugfix for this PR.
https://github.com/ota42y/openapi_parser/issues/22