### PR TITLE
Support one of validator

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -43,6 +43,17 @@ module OpenAPIParser
     end
   end
 
+  class NotOneOf < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} isn't one of in #{@reference}"
+    end
+  end
+
   class NotAnyOf < OpenAPIError
     def initialize(value, reference)
       super(reference)

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -9,6 +9,7 @@ require_relative 'schema_validators/object_validator'
 require_relative 'schema_validators/array_validator'
 require_relative 'schema_validators/any_of_validator'
 require_relative 'schema_validators/all_of_validator'
+require_relative 'schema_validators/one_of_validator'
 require_relative 'schema_validators/nil_validator'
 
 class OpenAPIParser::SchemaValidator
@@ -90,6 +91,7 @@ class OpenAPIParser::SchemaValidator
     def validator(value, schema)
       return any_of_validator if schema.any_of
       return all_of_validator if schema.all_of
+      return one_of_validator if schema.one_of
       return nil_validator if value.nil?
 
       case schema.type
@@ -140,6 +142,10 @@ class OpenAPIParser::SchemaValidator
 
     def all_of_validator
       @all_of_validator ||= OpenAPIParser::SchemaValidator::AllOfValidator.new(self, @coerce_value)
+    end
+
+    def one_of_validator
+      @one_of_validator ||= OpenAPIParser::SchemaValidator::OneOfValidator.new(self, @coerce_value)
     end
 
     def nil_validator

--- a/lib/openapi_parser/schema_validators/one_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/one_of_validator.rb
@@ -1,0 +1,18 @@
+class OpenAPIParser::SchemaValidator
+  class OneOfValidator < Base
+    # @param [Object] value
+    # @param [OpenAPIParser::Schemas::Schema] schema
+    def coerce_and_validate(value, schema)
+      # if multiple schemas are satisfied, it's not valid
+      result = schema.one_of.one? do |s|
+        _coerced, err = validatable.validate_schema(value, s)
+        err.nil?
+      end
+      if result
+        [value, nil]
+      else
+        [nil, OpenAPIParser::NotOneOf.new(value, schema.object_reference)]
+      end
+    end
+  end
+end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -224,6 +224,10 @@ paths:
                         id:
                           type: integer
                           format: int64
+                one_of_data:
+                  oneOf:
+                    - $ref: '#/components/schemas/one_of_object1'
+                    - $ref: '#/components/schemas/one_of_object2'
                 object_1:
                   type: object
                   properties:
@@ -569,3 +573,23 @@ components:
             type: array
             items:
               type: object
+    one_of_object1:
+      type: object
+      required:
+        - name
+        - integer_1
+      properties:
+        name:
+          type: string
+        integer_1:
+          type: integer
+    one_of_object2:
+      type: object
+      required:
+        - name
+        - string_1
+      properties:
+        name:
+          type: string
+        string_1:
+          type: string

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -336,6 +336,52 @@ RSpec.describe OpenAPIParser::SchemaValidator do
       end
     end
 
+    describe 'one_of' do
+      subject { request_operation.validate_request_body(content_type, { 'one_of_data' => params }) }
+
+      let(:correct_params) do
+        {
+          'name' => 'name',
+          'integer_1' => 42,
+        }
+      end
+      let(:params) { correct_params }
+
+      it { expect(subject).not_to eq nil }
+
+      context 'no schema matched' do
+        let(:params) do
+          {
+            'integer_1' => 42,
+          }
+        end
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::NotOneOf)).to eq true
+            expect(e.message.include?("isn't one of")).to eq true
+          end
+        end
+      end
+
+      context 'multiple schema matched' do
+        let(:params) do
+          {
+            'name' => 'name',
+            'integer_1' => 42,
+            'string_1' => 'string_1',
+          }
+        end
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::NotOneOf)).to eq true
+            expect(e.message.include?("isn't one of")).to eq true
+          end
+        end
+      end
+    end
+
     it 'unknown param' do
       expect(request_operation.validate_request_body(content_type, { 'unknown' => 1 })).to eq({ 'unknown' => 1 })
     end


### PR DESCRIPTION
Implement `oneOf` schema validator.

https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#oneof