### PR TITLE
Perform a strict check on object properties

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -43,6 +43,17 @@ module OpenAPIParser
     end
   end
 
+  class NotExistPropertyDefinition < OpenAPIError
+    def initialize(key, reference)
+      super(reference)
+      @key = key
+    end
+
+    def message
+      "property #{@key} is not defined in #{@reference}"
+    end
+  end
+
   class NotExistDiscriminatorMappingTarget < OpenAPIError
     def initialize(key, reference)
       super(reference)

--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -44,13 +44,13 @@ module OpenAPIParser
   end
 
   class NotExistPropertyDefinition < OpenAPIError
-    def initialize(key, reference)
+    def initialize(keys, reference)
       super(reference)
-      @key = key
+      @keys = keys
     end
 
     def message
-      "property #{@key} is not defined in #{@reference}"
+      "properties #{@keys.join(",")} are not defined in #{@reference}"
     end
   end
 

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -18,7 +18,7 @@ class OpenAPIParser::SchemaValidator
   # @param [Object] value
   # @param [OpenAPIParser::Schemas::Schema] schema
   module Validatable
-    def validate_schema(value, schema)
+    def validate_schema(value, schema, **keyword_args)
       raise 'implement'
     end
 
@@ -66,11 +66,15 @@ class OpenAPIParser::SchemaValidator
   # validate value eby schema
   # @param [Object] value
   # @param [OpenAPIParser::Schemas::Schema] schema
-  def validate_schema(value, schema)
+  def validate_schema(value, schema, **keyword_args)
     return [value, nil] unless schema
 
     if (v = validator(value, schema))
-      return v.coerce_and_validate(value, schema)
+      if keyword_args.empty?
+        return v.coerce_and_validate(value, schema)
+      else
+        return v.coerce_and_validate(value, schema, **keyword_args)
+      end
     end
 
     # unknown return error

--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -8,9 +8,7 @@ class OpenAPIParser::SchemaValidator
       # if any schema return error, it's not valida all of value
       schema.all_of.each do |s|
         # We need to store the reference to all of, so we can perform strict check on allowed properties
-        s.parent_all_of = schema.all_of
-
-        _coerced, err = validatable.validate_schema(value, s)
+        _coerced, err = validatable.validate_schema(value, s, :parent_all_of => schema.all_of)
         return [nil, err] if err
       end
       [value, nil]

--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -6,11 +6,26 @@ class OpenAPIParser::SchemaValidator
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema)
       # if any schema return error, it's not valida all of value
+      remaining_keys               = value.keys
+      nested_additional_properties = false
       schema.all_of.each do |s|
         # We need to store the reference to all of, so we can perform strict check on allowed properties
-        _coerced, err = validatable.validate_schema(value, s, :parent_all_of => schema.all_of)
+        _coerced, err = validatable.validate_schema(value, s, :parent_all_of => true)
+
+        if s.properties
+          remaining_keys               -= s.properties.keys
+          nested_additional_properties = true if s.additional_properties
+        end
+
         return [nil, err] if err
       end
+
+      # If there are nested additionalProperites, we allow not defined extra properties and lean on the specific
+      # additionalProperties validation
+      if !nested_additional_properties && !remaining_keys.empty?
+        return [nil, OpenAPIParser::NotExistPropertyDefinition.new(remaining_keys, schema.object_reference)]
+      end
+
       [value, nil]
     end
   end

--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -12,9 +12,12 @@ class OpenAPIParser::SchemaValidator
         # We need to store the reference to all of, so we can perform strict check on allowed properties
         _coerced, err = validatable.validate_schema(value, s, :parent_all_of => true)
 
-        if s.properties
-          remaining_keys               -= s.properties.keys
+        if s.type == "object"
+          remaining_keys               -= (s.properties || {}).keys
           nested_additional_properties = true if s.additional_properties
+        else
+          # If this is not allOf having array of objects inside, but e.g. having another anyOf/oneOf nested
+          remaining_keys.clear
         end
 
         return [nil, err] if err

--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -6,7 +6,7 @@ class OpenAPIParser::SchemaValidator
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema)
       # if any schema return error, it's not valida all of value
-      remaining_keys               = value.keys
+      remaining_keys               = value.kind_of?(Hash) ? value.keys : []
       nested_additional_properties = false
       schema.all_of.each do |s|
         # We need to store the reference to all of, so we can perform strict check on allowed properties

--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -7,6 +7,9 @@ class OpenAPIParser::SchemaValidator
     def coerce_and_validate(value, schema)
       # if any schema return error, it's not valida all of value
       schema.all_of.each do |s|
+        # We need to store the reference to all of, so we can perform strict check on allowed properties
+        s.parent_all_of = schema.all_of
+
         _coerced, err = validatable.validate_schema(value, s)
         return [nil, err] if err
       end

--- a/lib/openapi_parser/schema_validators/any_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/any_of_validator.rb
@@ -2,7 +2,7 @@ class OpenAPIParser::SchemaValidator
   class AnyOfValidator < Base
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
-    def coerce_and_validate(value, schema)
+    def coerce_and_validate(value, schema, **_keyword_args)
       if schema.discriminator
         return validate_discriminator_schema(schema.discriminator, value)
       end

--- a/lib/openapi_parser/schema_validators/base.rb
+++ b/lib/openapi_parser/schema_validators/base.rb
@@ -14,7 +14,7 @@ class OpenAPIParser::SchemaValidator
     # need override
     # @param [Array] _value
     # @param [OpenAPIParser::Schemas::Schema] _schema
-    def coerce_and_validate(_value, _schema)
+    def coerce_and_validate(_value, _schema, **_keyword_args)
       raise 'need implement'
     end
 

--- a/lib/openapi_parser/schema_validators/nil_validator.rb
+++ b/lib/openapi_parser/schema_validators/nil_validator.rb
@@ -2,7 +2,7 @@ class OpenAPIParser::SchemaValidator
   class NilValidator < Base
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
-    def coerce_and_validate(value, schema)
+    def coerce_and_validate(value, schema, **_keyword_args)
       return [value, nil] if schema.nullable
 
       [nil, OpenAPIParser::NotNullError.new(schema.object_reference)]

--- a/lib/openapi_parser/schema_validators/object_validator.rb
+++ b/lib/openapi_parser/schema_validators/object_validator.rb
@@ -17,8 +17,9 @@ class OpenAPIParser::SchemaValidator
                          remaining_keys.delete(name)
                          validatable.validate_schema(v, s)
                        else
-                         # Property is not defined, try validate using additionalProperties
-                         validate_using_additional_properties(schema, name, v)
+                         # TODO: we need to perform a validation based on schema.additional_properties here, if
+                         # additionalProperties are defined
+                         [v, nil]
                        end
 
         return [nil, err] if err
@@ -37,12 +38,6 @@ class OpenAPIParser::SchemaValidator
       value.merge!(coerced_values.to_h) if @coerce_value
 
       [value, nil]
-    end
-
-    def validate_using_additional_properties(schema, name, v)
-      # TODO: we need to perform a validation based on schema.additional_properties here
-
-      return [v, nil]
     end
   end
 end

--- a/lib/openapi_parser/schema_validators/object_validator.rb
+++ b/lib/openapi_parser/schema_validators/object_validator.rb
@@ -2,21 +2,26 @@ class OpenAPIParser::SchemaValidator
   class ObjectValidator < Base
     # @param [Hash] value
     # @param [OpenAPIParser::Schemas::Schema] schema
-    # @param [OpenAPIParser::Schemas::Schema, Nil] parent_all_of parent allOf schema if component is nested under allOf
-    def coerce_and_validate(value, schema, parent_all_of: nil)
+    # @param [Boolean] parent_all_of true if component is nested under allOf
+    def coerce_and_validate(value, schema, parent_all_of: false)
       return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Hash)
 
       return [value, nil] unless schema.properties
 
       required_set = schema.required ? schema.required.to_set : Set.new
+      remaining_keys = value.keys
 
       coerced_values = value.map do |name, v|
         s = schema.properties[name]
         coerced, err = if s
+                         remaining_keys.delete(name)
                          validatable.validate_schema(v, s)
                        else
+                         # If object is nested in all of, the validation is already done in allOf validator. Or if
+                         # additionalProperites are defined, we will validate using that
+                         remaining_keys.clear if parent_all_of || schema.additional_properties
                          # Property is not defined, try validate using additionalProperties
-                         validate_using_additional_properties(schema, name, v, parent_all_of)
+                         validate_using_additional_properties(schema, name, v) if schema.additional_properties
                        end
 
         return [nil, err] if err
@@ -25,6 +30,7 @@ class OpenAPIParser::SchemaValidator
         [name, coerced]
       end
 
+      return [nil, OpenAPIParser::NotExistPropertyDefinition.new(remaining_keys, schema.object_reference)] unless remaining_keys.empty?
       return [nil, OpenAPIParser::NotExistRequiredKey.new(required_set.to_a, schema.object_reference)] unless required_set.empty?
 
       value.merge!(coerced_values.to_h) if @coerce_value
@@ -32,35 +38,10 @@ class OpenAPIParser::SchemaValidator
       [value, nil]
     end
 
-    def validate_using_additional_properties(schema, name, v, parent_all_of)
-      unless schema.additional_properties
-        if parent_all_of
-          return [v, nil] if property_defined_in_all_of?(schema, name, parent_all_of)
-        end
-
-        # Property name is not defined in this schema, nor in any schema in the allOf definition, raise a failure.
-        return [nil, OpenAPIParser::NotExistPropertyDefinition.new(name, schema.object_reference)]
-      end
-
+    def validate_using_additional_properties(schema, name, v)
       # TODO: we need to perform a validation based on additionalProperties here
+
       return [v, nil]
-    end
-
-    def property_defined_in_all_of?(schema, name, parent_all_of)
-      parent_all_of.each do |s|
-        # Skip the current schema
-        next if schema == s
-
-        # If one of the composable schemas defined in allOf has the property name defined, we can skip it here, it will
-        # be validated in that particular schema.
-        return true if s.properties && s.properties.key?(name)
-
-        # If one of the composable schemas defined in allOf has additional_properties, we can skip the validation here,
-        # it will be validated in that particular schema.
-        return true if s.additional_properties
-      end
-
-      false
     end
   end
 end

--- a/lib/openapi_parser/schema_validators/one_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/one_of_validator.rb
@@ -2,7 +2,7 @@ class OpenAPIParser::SchemaValidator
   class OneOfValidator < Base
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
-    def coerce_and_validate(value, schema)
+    def coerce_and_validate(value, schema, **_keyword_args)
       if schema.discriminator
         return validate_discriminator_schema(schema.discriminator, value)
       end

--- a/lib/openapi_parser/schemas/base.rb
+++ b/lib/openapi_parser/schemas/base.rb
@@ -6,9 +6,6 @@ module OpenAPIParser::Schemas
 
     attr_reader :parent, :raw_schema, :object_reference, :root
 
-    # Parent allOf reference, if schema is nested in allOf
-    attr_accessor :parent_all_of
-
     # @param [OpenAPIParser::Schemas::Base]
     def initialize(object_reference, parent, root, raw_schema)
       @raw_schema = raw_schema

--- a/lib/openapi_parser/schemas/base.rb
+++ b/lib/openapi_parser/schemas/base.rb
@@ -6,6 +6,9 @@ module OpenAPIParser::Schemas
 
     attr_reader :parent, :raw_schema, :object_reference, :root
 
+    # Parent allOf reference, if schema is nested in allOf
+    attr_accessor :parent_all_of
+
     # @param [OpenAPIParser::Schemas::Base]
     def initialize(object_reference, parent, root, raw_schema)
       @raw_schema = raw_schema

--- a/spec/data/petstore-expanded.yaml
+++ b/spec/data/petstore-expanded.yaml
@@ -122,6 +122,8 @@ paths:
                 properties:
                   id:
                     type: integer
+                  message:
+                    type: string
         default:
           description: unexpected error
           content:

--- a/spec/data/petstore-with-discriminator.yaml
+++ b/spec/data/petstore-with-discriminator.yaml
@@ -77,6 +77,7 @@ components:
         nut_stock:
           nullable: true
           type: integer
+      additionalProperties: true
     CatBasket:
       type: object
       required:

--- a/spec/data/petstore-with-discriminator.yaml
+++ b/spec/data/petstore-with-discriminator.yaml
@@ -43,11 +43,13 @@ components:
             anyOf:
               - "$ref": "#/components/schemas/SquirrelBasket"
               - "$ref": "#/components/schemas/CatBasket"
+              - "$ref": "#/components/schemas/TurtleBasket"
             discriminator:
               propertyName: name
               mapping:
                 cats: "#/components/schemas/CatBasket"
                 squirrels: "#/components/schemas/SquirrelBasket"
+                turtles: "#/components/schemas/TurtleBasket"
     SquirrelBasket:
       type: object
       required:
@@ -107,4 +109,59 @@ components:
         milk_stock:
           nullable: true
           type: integer
+    TurtleBasket:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        content:
+          type: array
+          items:
+            "$ref": "#/components/schemas/NinjaTurtle"
+    NinjaTurtle:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        born_at:
+          format: date-time
+          nullable: true
+          type: string
+        description:
+          nullable: true
+          type: string
+        required_combat_style:
+          allOf:
+            - anyOf:
+              - "$ref": "#/components/schemas/DonatelloStyle"
+              - "$ref": "#/components/schemas/MichelangeloStyle"
+            - nullable: false
+              type: object
+        optional_combat_style:
+          anyOf:
+            - "$ref": "#/components/schemas/DonatelloStyle"
+            - "$ref": "#/components/schemas/MichelangeloStyle"
+    DonatelloStyle:
+      type: object
+      nullable: true
+      properties:
+        bo_color:
+          type: string
+        shuriken_count:
+          type: integer
+    MichelangeloStyle:
+      type: object
+      nullable: true
+      properties:
+        nunchaku_color:
+          type: string
+        grappling_hook_length:
+          type: number
+          format: double
+
+
 

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       }
 
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
-        # expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
+        expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
         expect(e.message).to match("^.*?(isn't any of).*?$")
       end
     end
@@ -194,7 +194,7 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       }
 
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
-        # expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
+        expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
         expect(e.message).to match("^.*?(isn't any of).*?$")
       end
     end

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -30,7 +30,32 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
 
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
         expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
-        expect(e.message).to match("^property unknown_key is not defined in.*?$")
+        expect(e.message).to match("^properties unknown_key are not defined in.*?$")
+      end
+    end
+
+    it 'throws error when sending multiple unknown property keys with no additionalProperties defined' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "cats",
+            "content" => [
+              {
+                "name"                => "Mr. Cat",
+                "born_at"             => "2019-05-16T11:37:02.160Z",
+                "description"         => "Cat gentleman",
+                "milk_stock"          => 10,
+                "unknown_key"         => "value",
+                "another_unknown_key" => "another_value"
+              }
+            ]
+          },
+        ]
+      }
+
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^properties unknown_key,another_unknown_key are not defined in.*?$")
       end
     end
 

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -80,5 +80,146 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
 
       request_operation.validate_request_body(content_type, body)
     end
+
+    it 'throws error when sending nil disallowed in allOf' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "required_combat_style" => nil,
+              }
+            ]
+          },
+        ]
+      }
+
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotNullError)).to eq true
+        expect(e.message).to match("^.*?(don't allow null).*?$")
+      end
+    end
+
+    it 'passing when sending nil nested to anyOf that is allowed' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "optional_combat_style" => nil,
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
+
+    it 'throws error when unknown attribute nested in allOf' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "required_combat_style" => {
+                  "bo_color"              => "brown",
+                  "grappling_hook_length" => 10.2
+                },
+              }
+            ]
+          },
+        ]
+      }
+
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        # expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
+        expect(e.message).to match("^.*?(isn't any of).*?$")
+      end
+    end
+
+    it 'passes error with correct attributes nested in allOf' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "required_combat_style" => {
+                  "bo_color"       => "brown",
+                  "shuriken_count" => 10
+                },
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
+
+    it 'throws error when unknown attribute nested in allOf' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "optional_combat_style" => {
+                  "bo_color"              => "brown",
+                  "grappling_hook_length" => 10.2
+                },
+              }
+            ]
+          },
+        ]
+      }
+
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        # expect(e.kind_of?(OpenAPIParser::NotAnyOf)).to eq true
+        expect(e.message).to match("^.*?(isn't any of).*?$")
+      end
+    end
+
+    it 'passes error with correct attributes nested in anyOf' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "turtles",
+            "content" => [
+              {
+                "name"                  => "Mr. Cat",
+                "born_at"               => "2019-05-16T11:37:02.160Z",
+                "description"           => "Cat gentleman",
+                "optional_combat_style" => {
+                  "bo_color"       => "brown",
+                  "shuriken_count" => 10
+                },
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
   end
 end

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../../spec_helper'
+
+RSpec.describe OpenAPIParser::Schemas::RequestBody do
+  let(:root) { OpenAPIParser.parse(petstore_with_discriminator_schema, {}) }
+
+  describe 'object properties' do
+    let(:content_type) { 'application/json' }
+    let(:http_method) { :post }
+    let(:request_path) { '/save_the_pets' }
+    let(:request_operation) { root.request_operation(http_method, request_path) }
+    let(:params) { {} }
+
+    it 'throws error when sending unknown property key with no additionalProperties defined' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "cats",
+            "content" => [
+              {
+                "name"        => "Mr. Cat",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Cat gentleman",
+                "milk_stock"  => 10,
+                "unknown_key" => "value"
+              }
+            ]
+          },
+        ]
+      }
+
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^property unknown_key is not defined in.*?$")
+      end
+    end
+
+    it 'ignores unknown property key if additionalProperties is defined' do
+      # TODO: we have to use additional properties to do the validation
+      body = {
+        "baskets" => [
+          {
+            "name"    => "squirrels",
+            "content" => [
+              {
+                "name"        => "Mrs. Squirrel",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Squirrel superhero",
+                "nut_stock"   => 10,
+                "unknown_key" => "value"
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
+  end
+end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -383,7 +383,10 @@ RSpec.describe OpenAPIParser::SchemaValidator do
     end
 
     it 'unknown param' do
-      expect(request_operation.validate_request_body(content_type, { 'unknown' => 1 })).to eq({ 'unknown' => 1 })
+      expect { request_operation.validate_request_body(content_type, { 'unknown' => 1 }) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^property unknown is not defined in.*?$")
+      end
     end
 
     describe 'invalid type' do

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
     it 'unknown param' do
       expect { request_operation.validate_request_body(content_type, { 'unknown' => 1 }) }.to raise_error do |e|
         expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
-        expect(e.message).to match("^property unknown is not defined in.*?$")
+        expect(e.message).to match("^properties unknown are not defined in.*?$")
       end
     end
 

--- a/spec/openapi_parser/schemas/discriminator_spec.rb
+++ b/spec/openapi_parser/schemas/discriminator_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       }
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
         expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
-        expect(e.message).to match("^property nut_stock is not defined in.*?$")
+        expect(e.message).to match("^properties nut_stock are not defined in.*?$")
       end
     end
 

--- a/spec/openapi_parser/schemas/discriminator_spec.rb
+++ b/spec/openapi_parser/schemas/discriminator_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
         ]
       }
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
-        expect(e.kind_of?(OpenAPIParser::NotExistRequiredKey)).to eq true
-        expect(e.message).to match("^required parameters milk_stock not exist.*?$")
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^property nut_stock is not defined in.*?$")
       end
     end
 


### PR DESCRIPTION
Perform a strict check on properties

We need to throw a validation error if property being send is
not defined. If additionalProperties are defined, we skip the
validation for now, with TODO added.

In a case of composing schema using allOf, the property needs
to be defined at least in 1 of te allOf items, as stated in:

https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof

Depends on:
- [x] https://github.com/ota42y/openapi_parser/pull/32 (affecting the spec here, so commits of this PR added as dependency and will be rebased when merged)
