### PR TITLE
Support discriminator without mapping

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -54,14 +54,14 @@ module OpenAPIParser
     end
   end
 
-  class NotExistDiscriminatorMappingTarget < OpenAPIError
-    def initialize(key, reference)
+  class NotExistDiscriminatorMappedSchema < OpenAPIError
+    def initialize(mapped_schema_reference, reference)
       super(reference)
-      @key = key
+      @mapped_schema_reference = mapped_schema_reference
     end
 
     def message
-      "discriminator mapping key #{@key} does not exist in #{@reference}"
+      "discriminator mapped schema #{@mapped_schema_reference} does not exist in #{@reference}"
     end
   end
 

--- a/lib/openapi_parser/schema_validators/base.rb
+++ b/lib/openapi_parser/schema_validators/base.rb
@@ -32,7 +32,7 @@ class OpenAPIParser::SchemaValidator
       resolved_schema = discriminator.root.find_object(mapping_target)
 
       unless resolved_schema
-        return [nil, OpenAPIParser::NotExistDiscriminatorMappingTarget.new(mapping_key, discriminator.object_reference)]
+        return [nil, OpenAPIParser::NotExistDiscriminatorMappedSchema.new(mapping_target, discriminator.object_reference)]
       end
       validatable.validate_schema(value, resolved_schema, {discriminator_property_name: discriminator.property_name})
     end

--- a/lib/openapi_parser/schema_validators/base.rb
+++ b/lib/openapi_parser/schema_validators/base.rb
@@ -26,16 +26,14 @@ class OpenAPIParser::SchemaValidator
 
       # it's allowed to have discriminator without mapping, then we need to lookup discriminator.property_name
       # but the format is not the full path, just model name in the components
-      mapping = discriminator.mapping || ->(key) { "#/components/schemas/#{key}" }
-
-      mapping_target = mapping[mapping_key]
-      unless mapping_target
-        return [nil, OpenAPIParser::NotExistDiscriminatorMappingTarget.new(mapping_key, discriminator.object_reference)]
-      end
+      mapping_target = discriminator.mapping&.[](mapping_key) || "#/components/schemas/#{mapping_key}"
 
       # Find object does O(n) search at worst, then caches the result, so this is ok for repeated search
       resolved_schema = discriminator.root.find_object(mapping_target)
 
+      unless resolved_schema
+        return [nil, OpenAPIParser::NotExistDiscriminatorMappingTarget.new(mapping_key, discriminator.object_reference)]
+      end
       validatable.validate_schema(value, resolved_schema, {discriminator_property_name: discriminator.property_name})
     end
   end

--- a/lib/openapi_parser/schema_validators/base.rb
+++ b/lib/openapi_parser/schema_validators/base.rb
@@ -24,9 +24,11 @@ class OpenAPIParser::SchemaValidator
       end
       mapping_key = value[discriminator.property_name]
 
-      # TODO: it's allowed to have discriminator without mapping, then we need to lookup discriminator.property_name
+      # it's allowed to have discriminator without mapping, then we need to lookup discriminator.property_name
       # but the format is not the full path, just model name in the components
-      mapping_target = discriminator.mapping[mapping_key]
+      mapping = discriminator.mapping || ->(key) { "#/components/schemas/#{key}" }
+
+      mapping_target = mapping[mapping_key]
       unless mapping_target
         return [nil, OpenAPIParser::NotExistDiscriminatorMappingTarget.new(mapping_key, discriminator.object_reference)]
       end

--- a/spec/data/petstore-with-discriminator.yaml
+++ b/spec/data/petstore-with-discriminator.yaml
@@ -32,6 +32,24 @@ paths:
             application/json:
               schema:
                 type: object
+  /save_the_pets_without_mapping:
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetBasketsWithoutMapping'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   schemas:
     PetBaskets:
@@ -54,6 +72,17 @@ components:
                 turtles: "#/components/schemas/TurtleBasket"
                 dragon: "#/components/schemas/Dragon"
                 hydra: "#/components/schemas/Hydra"
+    PetBasketsWithoutMapping:
+      type: object
+      properties:
+        baskets:
+          type: array
+          items:
+            anyOf:
+              - "$ref": "#/components/schemas/SquirrelBasket"
+              - "$ref": "#/components/schemas/CatBasket"
+            discriminator:
+              propertyName: name
     SquirrelBasket:
       type: object
       required:

--- a/spec/openapi_parser/schemas/discriminator_spec.rb
+++ b/spec/openapi_parser/schemas/discriminator_spec.rb
@@ -30,11 +30,53 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       request_operation.validate_request_body(content_type, body)
     end
 
+    it 'picks correct object based on implicit mapping and succeeds' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "CatBasket",
+            "content" => [
+              {
+                "name"        => "Mr. Cat",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Cat gentleman",
+                "milk_stock"  => 10
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
+
     it 'picks correct object based on mapping and fails' do
       body = {
         "baskets" => [
           {
             "name"    => "cats",
+            "content" => [
+              {
+                "name"        => "Mr. Cat",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Cat gentleman",
+                "nut_stock"   => 10 # passing squirrel attribute here, but discriminator still picks cats and fails
+              }
+            ]
+          },
+        ]
+      }
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^properties nut_stock are not defined in.*?$")
+      end
+    end
+
+    it 'picks correct object based on implicit mapping and fails' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "CatBasket",
             "content" => [
               {
                 "name"        => "Mr. Cat",

--- a/spec/openapi_parser/schemas/discriminator_spec.rb
+++ b/spec/openapi_parser/schemas/discriminator_spec.rb
@@ -97,4 +97,53 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       end
     end
   end
+
+  describe 'discriminator without mapping' do
+    let(:content_type) { 'application/json' }
+    let(:http_method) { :post }
+    let(:request_path) { '/save_the_pets_without_mapping' }
+    let(:request_operation) { root.request_operation(http_method, request_path) }
+
+    it 'picks correct object based on implicit mapping and succeeds' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "CatBasket",
+            "content" => [
+              {
+                "name"        => "Mr. Cat",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Cat gentleman",
+                "milk_stock"  => 10
+              }
+            ]
+          },
+        ]
+      }
+
+      request_operation.validate_request_body(content_type, body)
+    end
+
+    it 'picks correct object based on implicit mapping and fails' do
+      body = {
+        "baskets" => [
+          {
+            "name"    => "CatBasket",
+            "content" => [
+              {
+                "name"        => "Mr. Cat",
+                "born_at"     => "2019-05-16T11:37:02.160Z",
+                "description" => "Cat gentleman",
+                "nut_stock"   => 10 # passing squirrel attribute here, but discriminator still picks cats and fails
+              }
+            ]
+          },
+        ]
+      }
+      expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+        expect(e.kind_of?(OpenAPIParser::NotExistPropertyDefinition)).to eq true
+        expect(e.message).to match("^properties nut_stock are not defined in.*?$")
+      end
+    end
+  end
 end

--- a/spec/openapi_parser/schemas/discriminator_spec.rb
+++ b/spec/openapi_parser/schemas/discriminator_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe OpenAPIParser::Schemas::RequestBody do
       }
 
       expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
-        expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorMappingTarget)).to eq true
-        expect(e.message).to match("^discriminator mapping key dogs does not exist.*?$")
+        expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorMappedSchema)).to eq true
+        expect(e.message).to match("^discriminator mapped schema #/components/schemas/dogs does not exist.*?$")
       end
     end
 


### PR DESCRIPTION
When schema includes a discriminator without mapping, validation raises following error.

```
Failure/Error: mapping_target = discriminator.mapping[mapping_key]

NoMethodError:
   undefined method `[]' for nil:NilClass
```

### Concerns

[OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject) is not clear about implicit mapping resolution and I just use `"#/components/schemas/#{key}"`, but it might be better to choose `$ref` from `oneOf`, `anyOf` or `allOf` list.