### PR TITLE
Add minimum and maximum checks for `integer` and `number` data types

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -110,6 +110,50 @@ module OpenAPIParser
     end
   end
 
+  class LessThanMinimum < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} cannot be less than minimum value of #{@reference}"
+    end
+  end
+
+  class LessThanExclusiveMinimum < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} cannot be less than or equal to exclusive minimum value of #{@reference}"
+    end
+  end
+
+  class MoreThanMaximum < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} cannot be more than maximum value of #{@reference}"
+    end
+  end
+
+  class MoreThanExclusiveMaximum < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} cannot be more than or equal to exclusive maximum value of #{@reference}"
+    end
+  end
+
   class InvalidPattern < OpenAPIError
     def initialize(value, pattern, reference)
       super(reference)

--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -117,7 +117,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} cannot be less than minimum value of #{@reference}"
+      "#{@value} cannot be less than minimum value in #{@reference}"
     end
   end
 
@@ -128,7 +128,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} cannot be less than or equal to exclusive minimum value of #{@reference}"
+      "#{@value} cannot be less than or equal to exclusive minimum value in #{@reference}"
     end
   end
 
@@ -139,7 +139,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} cannot be more than maximum value of #{@reference}"
+      "#{@value} cannot be more than maximum value in #{@reference}"
     end
   end
 
@@ -150,7 +150,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} cannot be more than or equal to exclusive maximum value of #{@reference}"
+      "#{@value} cannot be more than or equal to exclusive maximum value in #{@reference}"
     end
   end
 

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -1,5 +1,6 @@
 require_relative 'schema_validators/options'
 require_relative 'schema_validators/enumable'
+require_relative 'schema_validators/minimum_maximum'
 require_relative 'schema_validators/base'
 require_relative 'schema_validators/string_validator'
 require_relative 'schema_validators/integer_validator'

--- a/lib/openapi_parser/schema_validators/float_validator.rb
+++ b/lib/openapi_parser/schema_validators/float_validator.rb
@@ -1,6 +1,7 @@
 class OpenAPIParser::SchemaValidator
   class FloatValidator < Base
     include ::OpenAPIParser::SchemaValidator::Enumable
+    include ::OpenAPIParser::SchemaValidator::MinimumMaximum
 
     # validate float value by schema
     # @param [Object] value
@@ -19,6 +20,7 @@ class OpenAPIParser::SchemaValidator
         return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Numeric)
 
         check_enum_include(value, schema)
+        check_minimum_maximum(value, schema)
       end
 
       def coerce(value)

--- a/lib/openapi_parser/schema_validators/float_validator.rb
+++ b/lib/openapi_parser/schema_validators/float_validator.rb
@@ -19,7 +19,9 @@ class OpenAPIParser::SchemaValidator
       def coercer_and_validate_numeric(value, schema)
         return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Numeric)
 
-        check_enum_include(value, schema)
+        value, err = check_enum_include(value, schema)
+        return [nil, err] if err
+        
         check_minimum_maximum(value, schema)
       end
 

--- a/lib/openapi_parser/schema_validators/integer_validator.rb
+++ b/lib/openapi_parser/schema_validators/integer_validator.rb
@@ -1,6 +1,7 @@
 class OpenAPIParser::SchemaValidator
   class IntegerValidator < Base
     include ::OpenAPIParser::SchemaValidator::Enumable
+    include ::OpenAPIParser::SchemaValidator::MinimumMaximum
 
     # validate integer value by schema
     # @param [Object] value
@@ -11,6 +12,7 @@ class OpenAPIParser::SchemaValidator
       return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Integer)
 
       check_enum_include(value, schema)
+      check_minimum_maximum(value, schema)
     end
 
     private

--- a/lib/openapi_parser/schema_validators/integer_validator.rb
+++ b/lib/openapi_parser/schema_validators/integer_validator.rb
@@ -11,7 +11,9 @@ class OpenAPIParser::SchemaValidator
 
       return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Integer)
 
-      check_enum_include(value, schema)
+      value, err = check_enum_include(value, schema)
+      return [nil, err] if err
+
       check_minimum_maximum(value, schema)
     end
 

--- a/lib/openapi_parser/schema_validators/minimum_maximum.rb
+++ b/lib/openapi_parser/schema_validators/minimum_maximum.rb
@@ -1,18 +1,38 @@
 class OpenAPIParser::SchemaValidator
   module MinimumMaximum
-    # check enum value by schema
+    # check minimum and maximum value by schema
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     def check_minimum_maximum(value, schema)
-      include_min_max = schema.minimum || schema.exclusiveMinimum || schema.maximum || schema.exclusiveMaximum
+      include_min_max = schema.minimum || schema.maximum
       return [value, nil] unless include_min_max
 
-      reference = schema.object_reference
-      return [nil, OpenAPIParser::LessThanMinimum.new(value, reference)] if schema.minimum && value < schema.minimum
-      return [nil, OpenAPIParser::LessThanExclusiveMinimum.new(value, reference)] if schema.exclusiveMinimum && value <= schema.exclusiveMinimum
-      return [nil, OpenAPIParser::MoreThanMaximum.new(value, reference)] if schema.maximum && value > schema.maximum
-      return [nil, OpenAPIParser::MoreThanExclusiveMaximum.new(value, reference)] if schema.exclusiveMaximum && value >= schema.exclusiveMaximum
+      validate(value, schema)
       [value, nil]
+    rescue OpenAPIParser::OpenAPIError => e
+      return [nil, e]
     end
+
+    private
+
+      def validate(value, schema)
+        reference = schema.object_reference
+
+        if schema.minimum
+          if schema.exclusiveMinimum && value <= schema.minimum
+            raise OpenAPIParser::LessThanExclusiveMinimum.new(value, reference)
+          elsif value < schema.minimum
+            raise OpenAPIParser::LessThanMinimum.new(value, reference)
+          end
+        end
+
+        if schema.maximum
+          if schema.exclusiveMaximum && value >= schema.maximum
+            raise OpenAPIParser::MoreThanExclusiveMaximum.new(value, reference)
+          elsif value > schema.maximum
+            raise OpenAPIParser::MoreThanMaximum.new(value, reference)
+          end
+        end
+      end
   end
 end

--- a/lib/openapi_parser/schema_validators/minimum_maximum.rb
+++ b/lib/openapi_parser/schema_validators/minimum_maximum.rb
@@ -1,0 +1,18 @@
+class OpenAPIParser::SchemaValidator
+  module MinimumMaximum
+    # check enum value by schema
+    # @param [Object] value
+    # @param [OpenAPIParser::Schemas::Schema] schema
+    def check_minimum_maximum(value, schema)
+      include_min_max = schema.minimum || schema.exclusiveMinimum || schema.maximum || schema.exclusiveMaximum
+      return [value, nil] unless include_min_max
+
+      reference = schema.object_reference
+      return [nil, OpenAPIParser::LessThanMinimum.new(value, reference)] if schema.minimum && value < schema.minimum
+      return [nil, OpenAPIParser::LessThanExclusiveMinimum.new(value, reference)] if schema.exclusiveMinimum && value <= schema.exclusiveMinimum
+      return [nil, OpenAPIParser::MoreThanMaximum.new(value, reference)] if schema.maximum && value > schema.maximum
+      return [nil, OpenAPIParser::MoreThanExclusiveMaximum.new(value, reference)] if schema.exclusiveMaximum && value >= schema.exclusiveMaximum
+      [value, nil]
+    end
+  end
+end

--- a/spec/openapi_parser/schema_validator/integer_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/integer_validator_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
       {
         my_integer: {
           type: 'integer',
-          exclusiveMaximum: 10,
+          maximum: 10,
+          exclusiveMaximum: true,
         },
       }
     end
@@ -116,7 +117,8 @@ RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
       {
         my_integer: {
           type: 'integer',
-          exclusiveMinimum: 10,
+          minimum: 10,
+          exclusiveMinimum: true,
         },
       }
     end

--- a/spec/openapi_parser/schema_validator/integer_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/integer_validator_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../../spec_helper'
+
+RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
+  let(:replace_schema) { {} }
+  let(:root) { OpenAPIParser.parse(build_validate_test_schema(replace_schema), config) }
+  let(:config) { {} }
+  let(:target_schema) do
+    root.paths.path['/validate_test'].operation(:post).request_body.content['application/json'].schema
+  end
+  let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
+
+  describe 'validate integer maximum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          maximum: 10,
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'my_integer' => 10 } }
+      it { expect(subject).to eq({ 'my_integer' => 10 }) }
+    end
+
+    context 'invalid' do
+      context 'more than maximum' do
+        let(:more_than_maximum) { 11 }
+        let(:params) { { 'my_integer' => more_than_maximum } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::MoreThanMaximum)).to eq true
+            expect(e.message.start_with?("#{more_than_maximum} cannot be more than maximum")).to eq true
+          end
+        end
+      end
+    end
+  end
+
+  describe 'validate integer minimum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          minimum: 10,
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'my_integer' => 10 } }
+      it { expect(subject).to eq({ 'my_integer' => 10 }) }
+    end
+
+    context 'invalid' do
+      context 'less than minimum' do
+        let(:less_than_minimum) { 9 }
+        let(:params) { { 'my_integer' => less_than_minimum } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::LessThanMinimum)).to eq true
+            expect(e.message.start_with?("#{less_than_minimum} cannot be less than minimum")).to eq true
+          end
+        end
+      end
+    end
+  end
+
+  describe 'validate integer exclusiveMaximum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          exclusiveMaximum: 10,
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'my_integer' => 9 } }
+      it { expect(subject).to eq({ 'my_integer' => 9 }) }
+    end
+
+    context 'invalid' do
+      context 'more than or equal to exclusive maximum' do
+        let(:more_than_equal_exclusive_maximum) { 10 }
+        let(:params) { { 'my_integer' => more_than_equal_exclusive_maximum } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::MoreThanExclusiveMaximum)).to eq true
+            expect(e.message.start_with?("#{more_than_equal_exclusive_maximum} cannot be more than or equal to exclusive maximum")).to eq true
+          end
+        end
+      end
+    end
+  end
+
+  describe 'validate integer exclusiveMinimum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          exclusiveMinimum: 10,
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'my_integer' => 11 } }
+      it { expect(subject).to eq({ 'my_integer' => 11 }) }
+    end
+
+    context 'invalid' do
+      context 'less than or equal to exclusive minimum' do
+        let(:less_than_equal_exclusive_minimum) { 10 }
+        let(:params) { { 'my_integer' => less_than_equal_exclusive_minimum } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::LessThanExclusiveMinimum)).to eq true
+            expect(e.message.start_with?("#{less_than_equal_exclusive_minimum} cannot be less than or equal to exclusive minimum")).to eq true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### summary

This feature is to implement a simple check for `mininum`, `maximum` and also the `exclusiveMinimum` and `exclusiveMaximum` values for integer and number data type.

I added 4 specific Error classes for granularity.