### PR TITLE
Improve PathItemFinder

### DIFF
--- a/lib/openapi_parser/path_item_finder.rb
+++ b/lib/openapi_parser/path_item_finder.rb
@@ -1,10 +1,7 @@
 class OpenAPIParser::PathItemFinder
   # @param [OpenAPIParser::Schemas::Paths] paths
   def initialize(paths)
-    @root = PathNode.new('/')
     @paths = paths
-
-    @paths.path.each { |path, _path_item_object| @root.register_path_node(path.split('/'), path) }
   end
 
   # find operation object and if not exist return nil
@@ -41,71 +38,83 @@ class OpenAPIParser::PathItemFinder
     end
   end
 
-  # path tree node
-  class PathNode
-    attr_accessor :full_path, :name
-
-    def initialize(name)
-      @name = name
-      @children = Hash.new { |h, k| h[k] = PathNode.new(k) }
-      @path_template_node = nil # we can't initialize because recursive initialize...
-      @full_path = nil
-    end
-
-    # @param [Array<string>] splited_path
-    # @param [String] full_path
-    def register_path_node(splited_path, full_path)
-      if splited_path.empty?
-        @full_path = full_path
-        return
-      end
-
-      path_name = splited_path.shift
-
-      child = path_template?(path_name) ? path_template_node(path_name) : children[path_name]
-      child.register_path_node(splited_path, full_path)
-    end
-
-    # @return [String, nil] and Hash
-    def find_full_path(splited_path)
-      return [@full_path, {}] if splited_path.empty?
-
-      path_name = splited_path.shift
-
-      # when ambiguous matching like this
-      # /{entity}/me
-      # /books/{id}
-      # OpenAPI3 depend on the tooling so we use concrete one (using /books/)
-
-      path_params = {}
-      if children.has_key?(path_name)
-        child = children[path_name]
-      else
-        child = path_template_node(path_name)
-        path_params = { child.name.to_s => path_name }
-      end
-
-      ret, other_path_params = child.find_full_path(splited_path)
-      [ret, path_params.merge(other_path_params)]
-    end
-
-    private
-
-      attr_reader :children
-
-      def path_template_node(path_name)
-        @path_template_node ||= PathNode.new(path_name[1..(path_name.length - 2)]) # delete {} from {name}
-      end
-
-      def path_template?(path_name)
-        path_name.start_with?('{') && path_name.end_with?('}')
-      end
-  end
-
   private
+    # check if there is a identical path in the schema (without any param)
+    def matches_directly?(request_path, http_method)
+      @paths.path[request_path]&.operation(http_method)
+    end
+
+    # used to filter paths with different depth or without given http method
+    def different_depth_or_method?(splitted_schema_path, splitted_request_path, path_item, http_method)
+      splitted_schema_path.size != splitted_request_path.size || !path_item.operation(http_method)
+    end
+
+    # check if the path item is a template
+    # EXAMPLE: path_template?('{id}') => true
+    def path_template?(schema_path_item)
+      schema_path_item.start_with?('{') && schema_path_item.end_with?('}')
+    end
+
+    # get the parameter name from the schema path item
+    # EXAMPLE: param_name('{id}') => 'id'
+    def param_name(schema_path_item)
+      schema_path_item[1..(schema_path_item.length - 2)]
+    end
+
+    # extract params by comparing the request path and the path from schema
+    # EXAMPLE:
+    # extract_params(['org', '1', 'user', '2', 'edit'], ['org', '{org_id}', 'user', '{user_id}'])
+    # => { 'org_id' => 1, 'user_id' => 2 }
+    # return nil if the schema does not match
+    def extract_params(splitted_request_path, splitted_schema_path)
+      splitted_request_path.zip(splitted_schema_path).reduce({}) do |result, zip_item|
+        request_path_item, schema_path_item = zip_item
+
+        if path_template?(schema_path_item)
+          result[param_name(schema_path_item)] = request_path_item
+        else
+          return if schema_path_item != request_path_item
+        end
+
+        result
+      end
+    end
+
+    # find all matching patchs with parameters extracted
+    # EXAMPLE:
+    # [
+    #    ['/user/{id}/edit', { 'id' => 1 }],
+    #    ['/user/{id}/{action}', { 'id' => 1, 'action' => 'edit' }],
+    #  ]
+    def matching_paths_with_params(request_path, http_method)
+      splitted_request_path = request_path.split('/')
+
+      @paths.path.reduce([]) do |result, item|
+        path, path_item = item
+        splitted_schema_path = path.split('/')
+
+        next result if different_depth_or_method?(splitted_schema_path, splitted_request_path, path_item, http_method)
+        
+        extracted_params = extract_params(splitted_request_path, splitted_schema_path)
+        result << [path, extracted_params] if extracted_params
+        result
+      end
+    end
+
+    # find mathing path and extract params
+    # EXAMPLE: find_path_and_params('get', '/user/1') => ['/user/{id}', { 'id' => 1 }]
+    def find_path_and_params(http_method, request_path)
+      return [request_path, {}] if matches_directly?(request_path, http_method)
+      
+      matching = matching_paths_with_params(request_path, http_method)
+
+      # if there are many matching paths, return the one with the smallest number of params
+      # (prefer /user/{id}/action over /user/{param_1}/{param_2} )
+      matching.min_by { |match| match[0].size } 
+    end
 
     def parse_request_path(http_method, request_path)
-      original_path, path_params = @root.find_full_path(request_path.split('/'))
+      original_path, path_params = find_path_and_params(http_method, request_path)
       return nil unless original_path # # can't find
 
       path_item_object = @paths.path[original_path]

--- a/spec/data/petstore-expanded.yaml
+++ b/spec/data/petstore-expanded.yaml
@@ -214,6 +214,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /pets/{nickname}/adopt/{param_2}:
+    post:
+      description: Adopt a pet
+      operationId: adoptPet
+      parameters:
+      - name: nickname
+        in: path
+        description: Name of pet to adopt
+        required: true
+        schema:
+          type: string
+      - name: param_2
+        in: path
+        description: Sample parameter
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /animals/{id}:
     parameters:
     - name: id

--- a/spec/openapi_parser/path_item_finder_spec.rb
+++ b/spec/openapi_parser/path_item_finder_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe OpenAPIParser::PathItemFinder do
     it do
       expect(subject.class).to eq OpenAPIParser::PathItemFinder
 
-      expect(subject.instance_variable_get(:@root).send(:children).size).to eq 1
-
       result = subject.operation_object(:get, '/pets')
       expect(result.class).to eq OpenAPIParser::PathItemFinder::Result
       expect(result.original_path).to eq('/pets')
@@ -21,6 +19,13 @@ RSpec.describe OpenAPIParser::PathItemFinder do
       expect(result.original_path).to eq('/pets/{id}')
       expect(result.operation_object.object_reference).to eq root.find_object('#/paths/~1pets~1{id}/get').object_reference
       expect(result.path_params['id']).to eq '1'
+
+      result = subject.operation_object(:post, '/pets/lessie/adopt/123')
+      expect(result.original_path).to eq('/pets/{nickname}/adopt/{param_2}')
+      expect(result.operation_object.object_reference)
+        .to eq root.find_object('#/paths/~1pets~1{nickname}~1adopt~1{param_2}/post').object_reference
+      expect(result.path_params['nickname']).to eq 'lessie'
+      expect(result.path_params['param_2']).to eq '123'
     end
   end
 end


### PR DESCRIPTION
I've discovered the edge case when the path and params are matched incorrectly even if the matched path doesn't contain searched HTTP method at all and path has completely different length. I've added the spec that proofs existence of the bug:
`spec/openapi_parser/path_item_finder_spec.rb`

I've rewritten `PathItemFinder` to fix this. Basically, what I'm doing is:
* filter paths by depth and HTTP method
* compare split paths arrays instead of recursive traversing
* if there are more matching paths, get the one with the smallest number of params
