### PR TITLE
add email format validation on string

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -166,6 +166,17 @@ module OpenAPIParser
     end
   end
 
+  class InvalidEmailFormat < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@value} is not a valid email address format in #{@reference}"
+    end
+  end
+
   class NotExistStatusCodeDefinition < OpenAPIError
     def message
       "don't exist status code definition in #{@reference}"

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -24,6 +24,9 @@ class OpenAPIParser::SchemaValidator
       value, err = validate_max_min_length(value, schema)
       return [nil, err] if err
 
+      value, err = validate_email_format(value, schema)
+      return [nil, err] if err
+
       [value, nil]
     end
 
@@ -60,6 +63,14 @@ class OpenAPIParser::SchemaValidator
         return [nil, OpenAPIParser::LessThanMinLength.new(value, schema.object_reference)] if schema.minLength && value.size < schema.minLength
 
         [value, nil]
+      end
+
+      def validate_email_format(value, schema)
+        return [value, nil] unless schema.format == 'email'
+
+        return [value, nil] if value.match?(URI::MailTo::EMAIL_REGEXP)
+
+        return [nil, OpenAPIParser::InvalidEmailFormat.new(value, schema.object_reference)]
       end
   end
 end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -109,4 +109,37 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
       end
     end
   end
+
+  describe 'validate email format' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        email_str: {
+          type: 'string',
+          format: 'email',
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'email_str' => 'hello@example.com' } }
+      it { expect(subject).to eq({ 'email_str' => 'hello@example.com' }) }
+    end
+
+    context 'invalid' do
+      context 'error pattern' do
+        let(:value) { 'not_email' }
+        let(:params) { { 'email_str' => value } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::InvalidEmailFormat)).to eq true
+            expect(e.message.start_with?("#{value} is not a valid email address format in")).to eq true
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #50 

I added a simple email format validation for openAPI string types