### PR TITLE
use match method

### DIFF
--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -68,7 +68,10 @@ class OpenAPIParser::SchemaValidator
       def validate_email_format(value, schema)
         return [value, nil] unless schema.format == 'email'
 
-        return [value, nil] if value.match?(URI::MailTo::EMAIL_REGEXP)
+        # match? method is good performance.
+        # So when we drop ruby 2.3 support we use match? method because this method add ruby 2.4
+        #return [value, nil] if value.match?(URI::MailTo::EMAIL_REGEXP)
+        return [value, nil] if value.match(URI::MailTo::EMAIL_REGEXP)
 
         return [nil, OpenAPIParser::InvalidEmailFormat.new(value, schema.object_reference)]
       end


### PR DESCRIPTION
match? method is good performance but it added ruby 2.4.
So we don't use ruby 2.3.

When we drop ruby 2.3 support, we should fix it
https://github.com/ota42y/openapi_parser/issues/52