### PR TITLE
Bugfix: validate non-nullable response header

### DIFF
--- a/lib/openapi_parser/schemas/response.rb
+++ b/lib/openapi_parser/schemas/response.rb
@@ -43,11 +43,11 @@ module OpenAPIParser::Schemas
       def validate_header(response_headers)
         return unless headers
 
-        headers.each do |k, v|
-          h = response_headers[k]
-          next unless h
+        headers.each do |name, schema|
+          next unless response_headers.key?(name)
 
-          v.validate(h)
+          value = response_headers[name]
+          schema.validate(value)
         end
       end
   end

--- a/spec/data/petstore-expanded.yaml
+++ b/spec/data/petstore-expanded.yaml
@@ -85,6 +85,8 @@ paths:
                 type: string
             x-limit:
               $ref: '#/components/headers/X-Rate-Limit-Limit'
+            non-nullable-x-limit:
+              $ref: '#/components/headers/Non-Nullable-X-Rate-Limit-Limit'
           content:
             application/json:
               schema:
@@ -312,3 +314,8 @@ components:
       description: The number of allowed requests in the current period
       schema:
         type: integer
+    Non-Nullable-X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      schema:
+        type: integer
+        nullable: false

--- a/spec/openapi_parser/request_operation_spec.rb
+++ b/spec/openapi_parser/request_operation_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe OpenAPIParser::RequestOperation do
         it { expect { subject }.to raise_error(OpenAPIParser::ValidateError) }
       end
 
+      context 'invalid non-nullbale header value' do
+        let(:headers) { headers_base.merge('non-nullable-x-limit' => nil) }
+
+        it { expect { subject }.to raise_error(OpenAPIParser::NotNullError) }
+      end
+
       context 'no check option' do
         let(:headers) { headers_base.merge('x-next': 'next', 'x-limit' => '1') }
         let(:init_config) { { validate_header: false } }


### PR DESCRIPTION
As per OpenAPI documentation, the [HeaderObject](https://swagger.io/specification/#headerObject)  follows the structure of the [Parameter Object ](https://swagger.io/specification/#parameterObject), that can specify the property `required`.

This PR adds the validation for the case when `header.schema.required = true` and the actual `header.value == nil`

The current response headers validation skips the validation when the header.value is `nil`, when actually should skip when the header is not present.

