### PR TITLE
fix object validator in case of properties missing

### DIFF
--- a/lib/openapi_parser/schema_validators/object_validator.rb
+++ b/lib/openapi_parser/schema_validators/object_validator.rb
@@ -7,13 +7,13 @@ class OpenAPIParser::SchemaValidator
     def coerce_and_validate(value, schema, parent_all_of: false, discriminator_property_name: nil)
       return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(Hash)
 
-      return [value, nil] unless schema.properties
+      properties = schema.properties || {}
 
       required_set = schema.required ? schema.required.to_set : Set.new
       remaining_keys = value.keys
 
       coerced_values = value.map do |name, v|
-        s = schema.properties[name]
+        s = properties[name]
         coerced, err = if s
                          remaining_keys.delete(name)
                          validatable.validate_schema(v, s)

--- a/spec/openapi_parser/schema_validator/object_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/object_validator_spec.rb
@@ -1,5 +1,29 @@
 require_relative '../../spec_helper'
 
+RSpec.describe OpenAPIParser::SchemaValidator::ObjectValidator do
+  before do
+    @validator = OpenAPIParser::SchemaValidator::ObjectValidator.new(nil, nil)
+    @root = OpenAPIParser.parse(
+      'openapi' => '3.0.0',
+      'components' => {
+        'schemas' => {
+          'object_with_required_but_no_properties' => {
+            'type' => 'object',
+            'required' => ['id'],
+          },
+        },
+      },
+    )
+  end
+
+  it 'shows error when required key is absent' do
+    schema = @root.components.schemas['object_with_required_but_no_properties']
+    _value, e = *@validator.coerce_and_validate({}, schema)
+
+    expect(e&.message).to match('^required parameters id not exist in.*?$')
+  end
+end
+
 RSpec.describe OpenAPIParser::Schemas::RequestBody do
 
 


### PR DESCRIPTION
The Schema Object of OpenAPI is derived from JSON Schema Specification Wright Draft 00, and `required` property has the same specification.
The specification says:

> 5.15.  required
>
>   The value of this keyword MUST be an array.  This array MUST have at
   least one element.  Elements of this array MUST be strings, and MUST
   be unique.
>
>   An object instance is valid against this keyword if its property set
   contains all elements in this keyword's array value.

It means `required` property should be checked whether `schema.properties` exists or not.

This PR fixes it.

I wrote a spec of it in a different way.
The reason why I did is

* It seems too difficult to add extra schema to existing fixtures
* It seems not a good idea to test validator through request_operation_object

So I test `ObjectValidator` directly.

Could you please review my fix and new idea of adding validator spec?