### PR TITLE
Avoid potential `.send(:exit)`

### DIFF
--- a/lib/openapi_parser/schemas/path_item.rb
+++ b/lib/openapi_parser/schemas/path_item.rb
@@ -12,7 +12,9 @@ module OpenAPIParser::Schemas
 
     # @return [Operation]
     def operation(method)
-      send(method)
+      public_send(method)
+    rescue NoMethodError
+      nil
     end
   end
 end

--- a/spec/openapi_parser/path_item_finder_spec.rb
+++ b/spec/openapi_parser/path_item_finder_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe OpenAPIParser::PathItemFinder do
       expect(result.path_params['id']).to eq '1'
     end
 
-    it "ignores invalid HTTP methods" do
+    it 'ignores invalid HTTP methods' do
       expect(subject.operation_object(:exit, '/pets')).to eq(nil)
       expect(subject.operation_object(:blah, '/pets')).to eq(nil)
     end

--- a/spec/openapi_parser/path_item_finder_spec.rb
+++ b/spec/openapi_parser/path_item_finder_spec.rb
@@ -22,5 +22,10 @@ RSpec.describe OpenAPIParser::PathItemFinder do
       expect(result.operation_object.object_reference).to eq root.find_object('#/paths/~1pets~1{id}/get').object_reference
       expect(result.path_params['id']).to eq '1'
     end
+
+    it "ignores invalid HTTP methods" do
+      expect(subject.operation_object(:exit, '/pets')).to eq(nil)
+      expect(subject.operation_object(:blah, '/pets')).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
Hi! I've been looking into OpenAPI for a new project and that led me to your project, which seems to be the leading parser in Ruby 🍻 Thanks for your work on it! 

I was just skimming the source and I noticed a place where `.send` was used with dynamic input. It seems like, depending on _where_ that input comes from, it could potentially be used to exit the Ruby process. 

I'd hate to open this up to external traffic, then have someone figure out a way to activate that codepath. It looks to me like `.public_send` would work just as well here, what do you think of changing it, just to make it _impossible_ that it would `exit`? 

(It looks like there are some other calls to `.send`, if you like this change and want to maintain consistency, I'd be happy to change those too. But it looks to me like they're all called with static input instead of dynamic input.)

Thanks for considering this change! Please let me know if there's anything I can do to improve it. 