### PR TITLE
Append the example to the Pattern validator error message

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -155,14 +155,15 @@ module OpenAPIParser
   end
 
   class InvalidPattern < OpenAPIError
-    def initialize(value, pattern, reference)
+    def initialize(value, pattern, reference, example)
       super(reference)
       @value = value
       @pattern = pattern
+      @example = example
     end
 
     def message
-      "#{@reference} pattern #{@pattern} does not match value: #{@value}"
+      "#{@reference} pattern #{@pattern} does not match value: #{@value}#{@example ? ", example: #{@example}" : ""}"
     end
   end
 

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -55,7 +55,7 @@ class OpenAPIParser::SchemaValidator
         return [value, nil] unless schema.pattern
         return [value, nil] if value =~ /#{schema.pattern}/
 
-        [nil, OpenAPIParser::InvalidPattern.new(value, schema.pattern, schema.object_reference)]
+        [nil, OpenAPIParser::InvalidPattern.new(value, schema.pattern, schema.object_reference, schema.example)]
       end
 
       def validate_max_min_length(value, schema)

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -28,14 +28,33 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
     end
 
     context 'invalid' do
-      context 'error pattern' do
-        let(:invalid_str) { '11922' }
-        let(:params) { { 'number_str' => invalid_str } }
+      let(:invalid_str) { '11922' }
+      let(:params) { { 'number_str' => invalid_str } }
 
+      context 'error pattern' do
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidPattern)
             expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str}")
+          end
+        end
+      end
+
+      context 'error pattern with example' do
+        let(:replace_schema) do
+          {
+            number_str: {
+              type: 'string',
+              pattern: '[0-9]+:[0-9]+',
+              example: '11:22'
+            },
+          }
+        end
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidPattern)
+            expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str}, example: 11:22")
           end
         end
       end


### PR DESCRIPTION
- append the example (if present) to the error message when using a pattern validator on a string type

This makes the error messages for pattern validation much easier by giving the user an example they can key off of. 

Before:
`"#/paths/~1validate_test/post/requestBody/content/application~1json/schema/properties/number_str pattern [0-9]+:[0-9]+ does not match value: 11922`

After:
`"#/paths/~1validate_test/post/requestBody/content/application~1json/schema/properties/number_str pattern [0-9]+:[0-9]+ does not match value: 11922, example: 11:22"`