### PR TITLE
Fix: Support nested query parameters defined with square brackets

### DIFF
--- a/lib/openapi_parser/parameter_validator.rb
+++ b/lib/openapi_parser/parameter_validator.rb
@@ -6,14 +6,29 @@ class OpenAPIParser::ParameterValidator
     # @param [OpenAPIParser::SchemaValidator::Options] options
     # @param [Boolean] is_header is header or not (ignore params key case)
     def validate_parameter(parameters_hash, params, object_reference, options, is_header = false)
+      return validate_header_parameter(parameters_hash, params, object_reference, options) if is_header
+
       no_exist_required_key = []
 
-      params_key_converted = params.keys.map { |k| [convert_key(k, is_header), k] }.to_h
       parameters_hash.each do |k, v|
-        key = params_key_converted[convert_key(k, is_header)]
-        if params.include?(key)
-          coerced = v.validate_params(params[key], options)
-          params[key] = coerced if options.coerce_value
+        path = k.scan(/\w+/m)
+        last_key = path.pop
+        parent_params = path.empty? ? params : params.dig(*path)
+
+        if parent_params && parent_params.include?(last_key)
+          coerced = v.validate_params(parent_params[last_key], options)
+          if options.coerce_value
+            parent_params[last_key] = coerced
+
+            until path.empty?
+              last_key = path.pop
+              prev_params = parent_params
+              parent_params = (path.empty? ? params : params.dig(*path))
+              parent_params[last_key] = prev_params
+            end
+
+            params = parent_params
+          end
         elsif v.required
           no_exist_required_key << k
         end
@@ -26,8 +41,23 @@ class OpenAPIParser::ParameterValidator
 
     private
 
-    def convert_key(k, is_header)
-      is_header ? k&.downcase : k
+    def validate_header_parameter(parameters_hash, params, object_reference, options)
+      no_exist_required_key = []
+
+      params_key_converted = params.keys.map { |k| [k.downcase, k] }.to_h
+      parameters_hash.each do |k, v|
+        key = params_key_converted[k.downcase]
+        if params.include?(key)
+          coerced = v.validate_params(params[key], options)
+          params[key] = coerced if options.coerce_value
+        elsif v.required
+          no_exist_required_key << k
+        end
+      end
+
+      raise OpenAPIParser::NotExistRequiredKey.new(no_exist_required_key, object_reference) unless no_exist_required_key.empty?
+
+      params
     end
   end
 end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -161,6 +161,43 @@ paths:
                 type: array
                 items:
                   type: string
+  /validate-nested:
+    post:
+      description: validate test data with query params
+      parameters:
+        - in: query
+          name: nested_object
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              value:
+                type: string
+                format: date-time
+        - in: query
+          name: nested_but_flat_object[name]
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: nested_but_flat_object[value]
+          required: true
+          schema:
+            type: string
+            format: date-time
+
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  string:
+                    type: string
   /validate:
     get:
       description: get characters


### PR DESCRIPTION
Currently I have the problem that parameters that are noted with square brackets, are not validated correctly. I use committee and all rack params are of course nested correctly.

I think semantically this should be the same and the values should be valid.

I have written some test cases and added a sample API definition.

I would be very happy to receive feedback.