### PR TITLE
Support $ref to objects in other OpenAPI yaml files

### DIFF
--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -1,4 +1,7 @@
+require 'uri'
 require 'time'
+require 'pathname'
+require 'open-uri'
 
 require 'openapi_parser/version'
 require 'openapi_parser/config'
@@ -13,14 +16,42 @@ require 'openapi_parser/reference_expander'
 
 module OpenAPIParser
   class << self
+    # Load schema yaml object. Uri is not set for returned schema.
     # @return [OpenAPIParser::Schemas::OpenAPI]
     def parse(schema, config = {})
-      c = Config.new(config)
-      root = Schemas::OpenAPI.new(schema, c)
-
-      OpenAPIParser::ReferenceExpander.expand(root) if c.expand_reference
-
-      root
+      load_yaml(schema, config: Config.new(config), uri: nil, schema_registry: {})
     end
+
+    # Load schema in specified filepath. If file path is relative, it is resolved using working directory.
+    # @return [OpenAPIParser::Schemas::OpenAPI]
+    def load(filepath, config = {})
+      path = Pathname.new(filepath)
+      path = Pathname.getwd + path if path.relative?
+      load_uri(URI::File.build(path: path.to_s), config: Config.new(config), schema_registry: {})
+    end
+
+    # Load schema located by the passed uri. Uri must be absolute.
+    # @return [OpenAPIParser::Schemas::OpenAPI]
+    def load_uri(uri, config:, schema_registry:)
+      # Open-uri doesn't open file scheme uri, so we try to open file path directly
+      # File scheme uri which points to a remote file is not supported.
+      content = if uri.scheme == 'file'
+        open(uri.path, &:read)
+      else
+        uri.open(&:read)
+      end
+
+      load_yaml(YAML.load(content), config: config, uri: uri, schema_registry: schema_registry)
+    end
+
+    private
+
+      def load_yaml(yaml, config:, uri:, schema_registry:)
+        root = Schemas::OpenAPI.new(yaml, config, uri: uri, schema_registry: schema_registry)
+
+        OpenAPIParser::ReferenceExpander.expand(root) if config.expand_reference
+
+        root
+      end
   end
 end

--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'time'
+require 'psych'
 require 'pathname'
 require 'open-uri'
 
@@ -41,7 +42,7 @@ module OpenAPIParser
         uri.open(&:read)
       end
 
-      load_yaml(YAML.load(content), config: config, uri: uri, schema_registry: schema_registry)
+      load_yaml(Psych.safe_load(content), config: config, uri: uri, schema_registry: schema_registry)
     end
 
     private

--- a/lib/openapi_parser/schemas/openapi.rb
+++ b/lib/openapi_parser/schemas/openapi.rb
@@ -5,11 +5,16 @@
 
 module OpenAPIParser::Schemas
   class OpenAPI < Base
-    def initialize(raw_schema, config)
+    def initialize(raw_schema, config, uri: nil, schema_registry: {})
       super('#', nil, self, raw_schema)
       @find_object_cache = {}
       @path_item_finder = OpenAPIParser::PathItemFinder.new(paths) if paths # invalid definition
       @config = config
+      @uri = uri
+      @schema_registry = schema_registry
+
+      # schema_registery is shared among schemas, and prevents a schema from being loaded multiple times
+      schema_registry[uri] = self if uri
     end
 
     # @!attribute [r] openapi
@@ -28,5 +33,27 @@ module OpenAPIParser::Schemas
     def request_operation(http_method, request_path)
       OpenAPIParser::RequestOperation.create(http_method, request_path, @path_item_finder, @config)
     end
+
+    # load another schema with shared config and schema_registry
+    # @return [OpenAPIParser::Schemas::OpenAPI]
+    def load_another_schema(uri)
+      resolved_uri = resolve_uri(uri)
+      return if resolved_uri.nil?
+
+      loaded = @schema_registry[resolved_uri]
+      return loaded if loaded
+
+      OpenAPIParser.load_uri(resolved_uri, config: @config, schema_registry: @schema_registry)
+    end
+
+    private
+
+      def resolve_uri(uri)
+        if uri.absolute?
+          uri
+        else
+          @uri&.merge(uri)
+        end
+      end
   end
 end

--- a/spec/data/cyclic-remote-ref1.yaml
+++ b/spec/data/cyclic-remote-ref1.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+paths:
+  /cyclic_reference:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: cyclic-remote-ref2.yaml#/components/schemas/outer
+      responses:
+        '200':
+          description: correct
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    inner:
+      type: integer

--- a/spec/data/cyclic-remote-ref2.yaml
+++ b/spec/data/cyclic-remote-ref2.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+components:
+  schemas:
+    outer:
+      type: object
+      properties:
+        content:
+          $ref: cyclic-remote-ref1.yaml#/components/schemas/inner
+      required:
+        - content

--- a/spec/data/petstore.json
+++ b/spec/data/petstore.json
@@ -1,0 +1,153 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/data/petstore.json.unsupported_extension
+++ b/spec/data/petstore.json.unsupported_extension
@@ -1,0 +1,153 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v1",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "type": "string",
+                "description": "A link to the next page of responses"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "schema": {
+              "$ref": "#/definitions/Pets"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Pets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pet"
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/data/petstore.yaml.unsupported_extension
+++ b/spec/data/petstore.yaml.unsupported_extension
@@ -1,0 +1,351 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+- url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      tags:
+      - tag_1
+      - tag_2
+      summary: sum
+      deprecated: true
+      parameters:
+      - name: tags
+        in: query
+        description: tags to filter by
+        required: false
+        style: form
+        allowEmptyValue: true
+        schema:
+          type: array
+          items:
+            type: string
+          additionalProperties:
+            type: string
+      - name: limit
+        in: query
+        description: maximum number of results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - $ref: '#/components/parameters/test'
+      - name: all_of_check
+        in: query
+        required: false
+        schema:
+          type: object
+          nullable: true
+          allOf:
+          - $ref: '#/components/parameters/test'
+          -
+            type: object
+            required:
+            - name
+            properties:
+              nmae:
+                type: string
+          properties:
+            pop:
+              type: string
+              readOnly: true
+              example: 'test'
+              deprecated: true
+            int:
+              type: integer
+              writeOnly: true
+          additionalProperties: true
+          description: desc
+      responses:
+        '200':
+          description: pet response
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+            x-limit:
+              $ref: '#/components/headers/X-Rate-Limit-Limit'
+            non-nullable-x-limit:
+              $ref: '#/components/headers/Non-Nullable-X-Rate-Limit-Limit'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            'application/unknown':
+              schema:
+                type: object
+            'application/*':
+              schema:
+                type: object
+            '*/*':
+              schema:
+                type: object
+        '4XX':
+          description: error response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+        '404':
+          description: 404 response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+                  message:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '201':
+          $ref: '#/components/responses/normal'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+      - name: id
+        in: path
+        description: ID of pet to fetch
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      parameters:
+      - name: id
+        in: path
+        description: ID of pet to fetch
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        $ref: '#/components/requestBodies/test_body'
+      responses:
+        '200':
+          $ref: '#/components/responses/normal'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+      - name: id
+        in: path
+        description: ID of pet to delete
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{nickname}/adopt/{param_2}:
+    post:
+      description: Adopt a pet
+      operationId: adoptPet
+      parameters:
+      - name: nickname
+        in: path
+        description: Name of pet to adopt
+        required: true
+        schema:
+          type: string
+      - name: param_2
+        in: path
+        description: Sample parameter
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /animals/{id}:
+    parameters:
+    - name: id
+      in: path
+      description: ID of pet to fetch
+      required: true
+      schema:
+        type: integer
+        format: int64
+    - name: token
+      in: header
+      description: token to be passed as a header
+      required: true
+      schema:
+        type: integer
+        format: int64
+      style: simple
+    get:
+      parameters:
+        - name: header_2
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  parameters:
+    test:
+      name: limit
+      in: query
+      description: maximum number of results to return
+      required: false
+      schema:
+        type: integer
+        format: int32
+    test_ref:
+      $ref: '#/components/parameters/test'
+  schemas:
+    Pet:
+      allOf:
+      - $ref: '#/components/schemas/NewPet'
+      - type: object
+        required:
+        - id
+        properties:
+          id:
+            type: integer
+            format: int64
+
+    NewPet:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+  responses:
+    normal:
+      description: pet response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Pet'
+  requestBodies:
+    test_body:
+      description: Pet to add to the store
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NewPet'
+  headers:
+    X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      schema:
+        type: integer
+    Non-Nullable-X-Rate-Limit-Limit:
+      description: The number of allowed requests in the current period
+      schema:
+        type: integer
+        nullable: false

--- a/spec/data/remote-file-ref.yaml
+++ b/spec/data/remote-file-ref.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+paths:
+  /local_file_reference:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: normal.yml#/components/schemas/all_of_base
+      responses:
+        '200':
+          description: correct
+          content:
+            application/json:
+              schema:
+                type: object

--- a/spec/data/remote-http-ref.yaml
+++ b/spec/data/remote-http-ref.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+paths:
+  /http_reference:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: https://raw.githubusercontent.com/ota42y/openapi_parser/091b20838cf0bfbc7bed2c9968b10bb0b9e8a789/spec/data/normal.yml#/components/schemas/all_of_base
+      responses:
+        '200':
+          description: correct
+          content:
+            application/json:
+              schema:
+                type: object

--- a/spec/openapi_parser/concerns/findable_spec.rb
+++ b/spec/openapi_parser/concerns/findable_spec.rb
@@ -21,4 +21,33 @@ RSpec.describe OpenAPIParser::Findable do
       expect(subject.find_object('#/paths/~1pets/get').object_reference).to eq root.paths.path['/pets'].get.object_reference
     end
   end
+
+  describe 'remote reference' do
+    describe 'local file reference' do
+      let(:root) { OpenAPIParser.load('spec/data/remote-file-ref.yaml') }
+      let(:request_operation) { root.request_operation(:post, '/local_file_reference') }
+
+      it 'validates request body using schema defined in another openapi yaml file' do
+        request_operation.validate_request_body('application/json', { 'name' => 'name' })
+      end
+    end
+
+    describe 'http reference' do
+      let(:root) { OpenAPIParser.load('spec/data/remote-http-ref.yaml') }
+      let(:request_operation) { root.request_operation(:post, '/http_reference') }
+
+      it 'validates request body using schema defined in openapi yaml file accessed via http' do
+        request_operation.validate_request_body('application/json', { 'name' => 'name' })
+      end
+    end
+
+    describe 'cyclic remote reference' do
+      let(:root) { OpenAPIParser.load('spec/data/cyclic-remote-ref1.yaml') }
+      let(:request_operation) { root.request_operation(:post, '/cyclic_reference') }
+
+      it 'validates request body using schema defined in another openapi yaml file' do
+        request_operation.validate_request_body('application/json', { 'content' => 1 })
+      end
+    end
+  end
 end

--- a/spec/openapi_parser_spec.rb
+++ b/spec/openapi_parser_spec.rb
@@ -1,4 +1,6 @@
 require_relative './spec_helper'
+require 'uri'
+require 'pathname'
 
 RSpec.describe OpenAPIParser do
   it 'has a version number' do
@@ -10,6 +12,39 @@ RSpec.describe OpenAPIParser do
       parsed = OpenAPIParser.parse(petstore_schema)
       root = OpenAPIParser.parse(petstore_schema, {})
       expect(parsed.openapi).to eq root.openapi
+    end
+  end
+
+  describe 'load' do
+    let(:loaded) { OpenAPIParser.load(petstore_schema_path, {}) }
+
+    it 'loads correct schema' do
+      root = OpenAPIParser.parse(petstore_schema, {})
+      expect(loaded.openapi).to eq root.openapi
+    end
+
+    it 'sets @uri' do
+      schema_path = (Pathname.getwd + petstore_schema_path).to_s
+      expect(loaded.instance_variable_get(:@uri).to_s).to eq "file://#{schema_path}"
+    end
+  end
+
+  describe 'load_uri' do
+    let(:schema_registry) { {} }
+    let(:uri) { URI::File.build(path: (Pathname.getwd + petstore_schema_path).to_s) }
+    let!(:loaded) { OpenAPIParser.load_uri(uri, config: OpenAPIParser::Config.new({}), schema_registry: schema_registry) }
+
+    it 'loads correct schema' do
+      root = OpenAPIParser.parse(petstore_schema, {})
+      expect(loaded.openapi).to eq root.openapi
+    end
+
+    it 'sets @uri' do
+      expect(loaded.instance_variable_get(:@uri)).to eq uri
+    end
+
+    it 'registers schema in schema_registry' do
+      expect(schema_registry).to eq({ uri => loaded })
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,18 @@ def petstore_with_discriminator_schema
   YAML.load_file('./spec/data/petstore-with-discriminator.yaml')
 end
 
+def json_petstore_schema_path
+  './spec/data/petstore.json'
+end
+
+def json_with_unsupported_extension_petstore_schema_path
+  './spec/data/petstore.json.unsupported_extension'
+end
+
+def yaml_with_unsupported_extension_petstore_schema_path
+  './spec/data/petstore.yaml.unsupported_extension'
+end
+
 def build_validate_test_schema(new_properties)
   b = YAML.load_file('./spec/data/validate_test.yaml')
   obj = b['paths']['/validate_test']['post']['requestBody']['content']['application/json']['schema']['properties']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,11 @@ def normal_schema
 end
 
 def petstore_schema
-  YAML.load_file('./spec/data/petstore-expanded.yaml')
+  YAML.load_file(petstore_schema_path)
+end
+
+def petstore_schema_path
+  './spec/data/petstore-expanded.yaml'
 end
 
 def petstore_with_discriminator_schema


### PR DESCRIPTION
Reference to files in local filesystem and files provided via http(s)/ftp is supported.

Changes are as follows:

- `@uri` is added to `OpenAPIParser::Schemas::OpenAPI`
  - It is used for resolving relative uri in $ref
- `@schema_registry` is added to `OpenAPIParser::Schemas::OpenAPI`
  - It is used for preventing schema from being loaded multiple times
- New methods to load schema are added to `OpenAPIParser`
  - The existing `#parse` method is not aware of schema content's location. I added new methods that also load files from filepath or uri, thus they can set uri for loaded schema.

I have following concerns.

- I did not put `@uri` and `@schema_registry` inside `config`, because I thought they do not fit into configuration. Interface would be simpler if I put them into config though.
- There are specs that download openapi yaml files via https. If you do not want to include http networking in specs, I will remove those specs.