### PR TITLE
Added support for validating UUID formatted strings

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -178,6 +178,17 @@ module OpenAPIParser
     end
   end
 
+  class InvalidUUIDFormat < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@reference} Value: #{@value} is not conformant with UUID format"
+    end
+  end
+
   class NotExistStatusCodeDefinition < OpenAPIError
     def message
       "#{@reference} status code definition does not exist"

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -27,6 +27,9 @@ class OpenAPIParser::SchemaValidator
       value, err = validate_email_format(value, schema)
       return [nil, err] if err
 
+      value, err = validate_uuid_format(value, schema)
+      return [nil, err] if err
+
       [value, nil]
     end
 
@@ -74,6 +77,14 @@ class OpenAPIParser::SchemaValidator
         return [value, nil] if value.match(URI::MailTo::EMAIL_REGEXP)
 
         return [nil, OpenAPIParser::InvalidEmailFormat.new(value, schema.object_reference)]
+      end
+
+      def validate_uuid_format(value, schema)
+        return [value, nil] unless schema.format == 'uuid'
+
+        return [value, nil] if value.match(/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/)
+
+        return [nil, OpenAPIParser::InvalidUUIDFormat.new(value, schema.object_reference)]
       end
   end
 end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -161,4 +161,37 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
       end
     end
   end
+
+  describe 'validate uuid format' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        uuid_str: {
+          type: 'string',
+          format: 'uuid',
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:params) { { 'uuid_str' => 'fd33fb1e-b1f6-401e-994d-8a2545e1aef7' } }
+      it { expect(subject).to eq({ 'uuid_str' => 'fd33fb1e-b1f6-401e-994d-8a2545e1aef7' }) }
+    end
+
+    context 'invalid' do
+      context 'error pattern' do
+        let(:value) { 'not_uuid' }
+        let(:params) { { 'uuid_str' => value } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidUUIDFormat)
+            expect(e.message).to end_with("Value: not_uuid is not conformant with UUID format")
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The openapi spec supports strings with UUID format. This PR adds support for validating UUID strings using regular expression.
