### PR TITLE
freeze pry version because failed in ruby 2.3.0

### DIFF
--- a/openapi_parser.gemspec
+++ b/openapi_parser.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'fincop'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry', '~> 0.12.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
I think we use pry in dev_dependency so we don't need drop ruby 2.3.0 support.