### PR TITLE
Allow $ref for path item objects

### DIFF
--- a/lib/openapi_parser/schemas/paths.rb
+++ b/lib/openapi_parser/schemas/paths.rb
@@ -2,6 +2,6 @@ module OpenAPIParser::Schemas
   class Paths < Base
     # @!attribute [r] path
     #   @return [Hash{String => PathItem, Reference}, nil]
-    openapi_attr_hash_body_objects 'path', PathItem, reference: false, allow_data_type: false
+    openapi_attr_hash_body_objects 'path', PathItem, reference: true, allow_data_type: false
   end
 end

--- a/spec/data/path-item-ref.yaml
+++ b/spec/data/path-item-ref.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+paths:
+  /sample:
+    post:
+      description: override here
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                test:
+                  type: string
+              required:
+                - test
+      responses:
+        '204':
+          description: empty
+  /ref-sample:
+    $ref: '#/paths/~1sample'

--- a/spec/openapi_parser/path_item_ref_spec.rb
+++ b/spec/openapi_parser/path_item_ref_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../spec_helper'
+
+RSpec.describe 'path item $ref' do
+  let(:root) { OpenAPIParser.parse(path_item_ref_schema, {}) }
+  let(:request_operation) { root.request_operation(:post, '/ref-sample') }
+
+  it 'understands path item $ref' do
+    ret = request_operation.validate_request_body('application/json', { 'test' => 'test' })
+    expect(ret).to eq({ 'test' => "test" })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,10 @@ def yaml_with_unsupported_extension_petstore_schema_path
   './spec/data/petstore.yaml.unsupported_extension'
 end
 
+def path_item_ref_schema
+  YAML.load_file('./spec/data/path-item-ref.yaml')
+end
+
 def build_validate_test_schema(new_properties)
   b = YAML.load_file('./spec/data/validate_test.yaml')
   obj = b['paths']['/validate_test']['post']['requestBody']['content']['application/json']['schema']['properties']


### PR DESCRIPTION
Path item object can have $ref, but currently it is not supported.

https://github.com/OAI/OpenAPI-Specification/blob/2d6a1809f3ee5c765a79db0ebc14bd2a03119c77/versions/3.0.2.md#path-item-object