### PR TITLE
Allow date and time content in YAML

### DIFF
--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -78,7 +78,7 @@ module OpenAPIParser
       end
 
       def parse_yaml(content)
-        Psych.safe_load(content)
+        Psych.safe_load(content, permitted_classes: [Date, Time])
       end
 
       def parse_json(content)

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -516,6 +516,27 @@ paths:
         default:
           "$ref": '#/components/responses/ref2'
 
+  /date_time:
+    get:
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date
+                  date-time:
+                    type: string
+                    format: date-time
+              example:
+                date: 2020-05-12
+                date-time: 2020-05-12T00:00:00.00Z
+
+
 components:
   parameters:
     ref1:


### PR DESCRIPTION
Add Date and Time to `Psych.safe_load`'s `permitted_classes`.

Using date or time in examples causes following error.

```
Psych::DisallowedClass:
  Tried to load unspecified class: Time
```