### PR TITLE
Find path by extracted params than path length, Close #75

### DIFF
--- a/lib/openapi_parser/path_item_finder.rb
+++ b/lib/openapi_parser/path_item_finder.rb
@@ -110,7 +110,7 @@ class OpenAPIParser::PathItemFinder
 
       # if there are many matching paths, return the one with the smallest number of params
       # (prefer /user/{id}/action over /user/{param_1}/{param_2} )
-      matching.min_by { |match| match[0].size } 
+      matching.min_by { |match| match[1].size } 
     end
 
     def parse_request_path(http_method, request_path)


### PR DESCRIPTION
`matching` in this context has the format of
```
['/user/{id}/edit', { 'id' => 1 }]
```
As the idea is to find matching path by minimum path params, the code should find min by the size of second element