### PR TITLE
Unescape ref URI before lookup in OpenAPIParser::Findable

### DIFF
--- a/lib/openapi_parser/concerns/findable.rb
+++ b/lib/openapi_parser/concerns/findable.rb
@@ -4,6 +4,7 @@ module OpenAPIParser::Findable
   # @param [String] reference
   # @return [OpenAPIParser::Findable]
   def find_object(reference)
+    reference = URI.unescape(reference)
     return self if object_reference == reference
     remote_reference = !reference.start_with?('#')
     return find_remote_object(reference) if remote_reference

--- a/spec/data/path-item-ref.yaml
+++ b/spec/data/path-item-ref.yaml
@@ -3,7 +3,13 @@ info:
   version: 1.0.0
   title: OpenAPI3 Test
 paths:
-  /sample:
+  /sample/{sample_id}:
+    parameters:
+      - name: sample_id
+        in: path
+        required: true
+        schema:
+          type: string
     post:
       description: override here
       requestBody:
@@ -20,4 +26,4 @@ paths:
         '204':
           description: empty
   /ref-sample:
-    $ref: '#/paths/~1sample'
+    $ref: '#/paths/~1sample~1%7Bsample_id%7D'


### PR DESCRIPTION
I was having a similar issue to #77. I _think_ this may fix that issue, but I'm not 100% sure.

Given that OpenAPI expects `$ref` values to be RFC3986-compliant percent-encoded, this can cause issues with embedded refs that live on a path with a parameter. The percent-encoding throws off the path matching in `find_object`. This PR simply URI unescapes the `ref` before attempting the lookup, which fixes the issue. Existing tests cover this functionality, so only a minor tweak to `path-item-ref.yaml` was required to validate the desired behavior. 

Example:

```yaml
  /sample/{sample_id}:

... snipped ...

  /ref-sample:
    $ref: '#/paths/~1sample~1%7Bsample_id%7D'
```

Also wanted to mention how much effort this library has saved me. Excellent work!