### PR TITLE
Validate path params defined on the path item

### DIFF
--- a/lib/openapi_parser/request_operation.rb
+++ b/lib/openapi_parser/request_operation.rb
@@ -41,6 +41,7 @@ class OpenAPIParser::RequestOperation
 
   def validate_path_params(options = nil)
     options ||= config.path_params_options
+    path_item&.validate_path_params(path_params, options)
     operation_object&.validate_path_params(path_params, options)
   end
 


### PR DESCRIPTION
Since parameters can be defined on both the path item or the operation, we need to validate path params against both objects, like we do with the query params.