### PR TITLE
fix typo

### DIFF
--- a/lib/openapi_parser/path_item_finder.rb
+++ b/lib/openapi_parser/path_item_finder.rb
@@ -80,7 +80,7 @@ class OpenAPIParser::PathItemFinder
       end
     end
 
-    # find all matching patchs with parameters extracted
+    # find all matching paths with parameters extracted
     # EXAMPLE:
     # [
     #    ['/user/{id}/edit', { 'id' => 1 }],


### PR DESCRIPTION
fix typo on comments for method

`patchs` -> `paths`