### PR TITLE
0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Find path by extracted params than path length #84
+* Unescape ref URI before lookup in OpenAPIParser::Findable #85
+* Improved path parameter matching code to allow file extensions, multiple parameters inside one path element, etc #90
+
 ## 0.11.2 (2020-05-23)
 * Allow date and time content in YAML #81
 

--- a/lib/openapi_parser/version.rb
+++ b/lib/openapi_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenAPIParser
-  VERSION = '0.11.2'.freeze
+  VERSION = '0.12.0'.freeze
 end


### PR DESCRIPTION
Include these changes.

* Find path by extracted params than path length #84
* Unescape ref URI before lookup in OpenAPIParser::Findable #85
* Improved path parameter matching code to allow file extensions, multiple parameters inside one path element, etc #90