### PR TITLE
Use CGI.unescape

### DIFF
--- a/lib/openapi_parser/concerns/findable.rb
+++ b/lib/openapi_parser/concerns/findable.rb
@@ -1,10 +1,11 @@
+require 'cgi'
 require 'uri'
 
 module OpenAPIParser::Findable
   # @param [String] reference
   # @return [OpenAPIParser::Findable]
   def find_object(reference)
-    reference = URI.unescape(reference)
+    reference = CGI.unescape(reference)
     return self if object_reference == reference
     remote_reference = !reference.start_with?('#')
     return find_remote_object(reference) if remote_reference


### PR DESCRIPTION
I got many obsolete warning messages after upgrade to v0.12.0.

```
.../vendor/bundle/ruby/2.7.0/gems/openapi_parser-0.12.0/lib/openapi_parser/concerns/findable.rb:7: warning: URI.unescape is obsolete
```

https://github.com/ruby/ruby/blob/master/lib/uri/common.rb#L132

