### PR TITLE
0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 0.12.1 (2020-08-27)
+* Use CGI.unescape (warning fix) #92
+
 ## 0.12.0 (2020-08-26)
 * Find path by extracted params than path length #84
 * Unescape ref URI before lookup in OpenAPIParser::Findable #85

--- a/lib/openapi_parser/version.rb
+++ b/lib/openapi_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenAPIParser
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.12.1'.freeze
 end


### PR DESCRIPTION
Include changes
* Use CGI.unescape (warning fix) #92