### PR TITLE
Fix a problem with remote reference to path items which have path parameters

### DIFF
--- a/lib/openapi_parser/concerns/findable.rb
+++ b/lib/openapi_parser/concerns/findable.rb
@@ -5,25 +5,26 @@ module OpenAPIParser::Findable
   # @param [String] reference
   # @return [OpenAPIParser::Findable]
   def find_object(reference)
-    reference = CGI.unescape(reference)
     return self if object_reference == reference
     remote_reference = !reference.start_with?('#')
     return find_remote_object(reference) if remote_reference
     return nil unless reference.start_with?(object_reference)
 
+    unescaped_reference = CGI.unescape(reference)
+
     @find_object_cache = {} unless defined? @find_object_cache
-    if (obj = @find_object_cache[reference])
+    if (obj = @find_object_cache[unescaped_reference])
       return obj
     end
 
-    if (child = _openapi_all_child_objects[reference])
-      @find_object_cache[reference] = child
+    if (child = _openapi_all_child_objects[unescaped_reference])
+      @find_object_cache[unescaped_reference] = child
       return child
     end
 
     _openapi_all_child_objects.values.each do |c|
-      if (obj = c.find_object(reference))
-        @find_object_cache[reference] = obj
+      if (obj = c.find_object(unescaped_reference))
+        @find_object_cache[unescaped_reference] = obj
         return obj
       end
     end

--- a/spec/data/remote-file-ref.yaml
+++ b/spec/data/remote-file-ref.yaml
@@ -18,3 +18,5 @@ paths:
             application/json:
               schema:
                 type: object
+  /reference_to_path_item_with_path_param:
+    $ref: 'path-item-ref.yaml#/paths/~1sample~1%7Bsample_id%7D'


### PR DESCRIPTION
Resolving remote reference to path items with path parameters causes URI::InvalidURIError.

Remote reference resolution creates URI from reference string. Path parameters uses '{' and '}', which are not usable in URI. So reference string needs to be kept escaped.