### PR TITLE
Use inspect to show error value

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -13,7 +13,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} expected #{@type}, but received #{@data.class}: #{@data}"
+      "#{@reference} expected #{@type}, but received #{@data.class}: #{@data.inspect}"
     end
 
     class << self
@@ -73,7 +73,7 @@ module OpenAPIParser
     end
 
     def message
-      "discriminator propertyName #{@key} does not exist in value #{@value} in #{@reference}"
+      "discriminator propertyName #{@key} does not exist in value #{@value.inspect} in #{@reference}"
     end
   end
 
@@ -84,7 +84,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} isn't one of in #{@reference}"
+      "#{@value.inspect} isn't one of in #{@reference}"
     end
   end
 
@@ -95,7 +95,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} isn't any of in #{@reference}"
+      "#{@value.inspect} isn't any of in #{@reference}"
     end
   end
 
@@ -106,7 +106,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value} isn't include enum in #{@reference}"
+      "#{@value.inspect} isn't include enum in #{@reference}"
     end
   end
 
@@ -117,7 +117,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} is less than minimum value"
+      "#{@reference} #{@value.inspect} is less than minimum value"
     end
   end
 
@@ -128,7 +128,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} cannot be less than or equal to exclusive minimum value"
+      "#{@reference} #{@value.inspect} cannot be less than or equal to exclusive minimum value"
     end
   end
 
@@ -139,7 +139,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} is more than maximum value"
+      "#{@reference} #{@value.inspect} is more than maximum value"
     end
   end
 
@@ -150,7 +150,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} cannot be more than or equal to exclusive maximum value"
+      "#{@reference} #{@value.inspect} cannot be more than or equal to exclusive maximum value"
     end
   end
 
@@ -163,7 +163,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} pattern #{@pattern} does not match value: #{@value}#{@example ? ", example: #{@example}" : ""}"
+      "#{@reference} pattern #{@pattern} does not match value: #{@value.inspect}#{@example ? ", example: #{@example}" : ""}"
     end
   end
 
@@ -174,7 +174,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} email address format does not match value: #{@value}"
+      "#{@reference} email address format does not match value: #{@value.inspect}"
     end
   end
 
@@ -185,7 +185,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} Value: #{@value} is not conformant with UUID format"
+      "#{@reference} Value: #{@value.inspect} is not conformant with UUID format"
     end
   end
 
@@ -208,7 +208,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} is longer than max length"
+      "#{@reference} #{@value.inspect} is longer than max length"
     end
   end
 
@@ -219,7 +219,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} is shorter than min length"
+      "#{@reference} #{@value.inspect} is shorter than min length"
     end
   end
 
@@ -230,7 +230,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} contains more than max items"
+      "#{@reference} #{@value.inspect} contains more than max items"
     end
   end
 
@@ -241,7 +241,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@reference} #{@value} contains fewer than min items"
+      "#{@reference} #{@value.inspect} contains fewer than min items"
     end
   end
 end

--- a/spec/openapi_parser/request_operation_spec.rb
+++ b/spec/openapi_parser/request_operation_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe OpenAPIParser::RequestOperation do
       it do
         expect { subject }.to raise_error do |e|
           expect(e).to be_kind_of(OpenAPIParser::ValidateError)
-          expect(e.message).to end_with("expected integer, but received String: 1")
+          expect(e.message).to end_with("expected integer, but received String: \"1\"")
         end
       end
     end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidPattern)
-            expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str}")
+            expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str.inspect}")
           end
         end
       end
@@ -54,7 +54,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidPattern)
-            expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str}, example: 11:22")
+            expect(e.message).to end_with("pattern [0-9]+:[0-9]+ does not match value: #{invalid_str.inspect}, example: 11:22")
           end
         end
       end
@@ -89,7 +89,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
           it do
             expect { subject }.to raise_error do |e|
               expect(e).to be_kind_of(OpenAPIParser::MoreThanMaxLength)
-              expect(e.message).to end_with("#{value} is longer than max length")
+              expect(e.message).to end_with("#{value.inspect} is longer than max length")
             end
           end
         end
@@ -121,7 +121,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
           it do
             expect { subject }.to raise_error do |e|
               expect(e).to be_kind_of(OpenAPIParser::LessThanMinLength)
-              expect(e.message).to end_with("#{value} is shorter than min length")
+              expect(e.message).to end_with("#{value.inspect} is shorter than min length")
             end
           end
         end
@@ -155,7 +155,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidEmailFormat)
-            expect(e.message).to end_with("email address format does not match value: not_email")
+            expect(e.message).to end_with("email address format does not match value: \"not_email\"")
           end
         end
       end
@@ -188,7 +188,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidUUIDFormat)
-            expect(e.message).to end_with("Value: not_uuid is not conformant with UUID format")
+            expect(e.message).to end_with("Value: \"not_uuid\" is not conformant with UUID format")
           end
         end
       end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
 
         expect { request_operation.validate_request_body(content_type, params) }.to raise_error do |e|
           expect(e).to be_kind_of(OpenAPIParser::ValidateError)
-          expect(e.message).to end_with("expected #{key}, but received #{value.class}: #{value}")
+          expect(e.message).to end_with("expected #{key}, but received #{value.class}: #{value.inspect}")
         end
       end
     end
@@ -242,7 +242,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         it 'not include enum' do
           expect { request_operation.validate_request_body(content_type, { 'enum_string' => 'x' }) }.to raise_error do |e|
             expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
-            expect(e.message.start_with?("x isn't include enum")).to eq true
+            expect(e.message.start_with?("\"x\" isn't include enum")).to eq true
           end
         end
       end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -245,6 +245,13 @@ RSpec.describe OpenAPIParser::SchemaValidator do
             expect(e.message.start_with?("\"x\" isn't include enum")).to eq true
           end
         end
+
+        it 'not include enum (empty string)' do
+          expect { request_operation.validate_request_body(content_type, { 'enum_string' => '' }) }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
+            expect(e.message.start_with?("\"\" isn't include enum")).to eq true
+          end
+        end
       end
 
       context 'enum integer' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler'
 require 'yaml'
-# require 'pry'
+require 'pry'
 require 'rspec-parameterized'
 require 'simplecov'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-require 'bundler/setup'
+require 'bundler'
 require 'yaml'
-require 'pry'
+# require 'pry'
 require 'rspec-parameterized'
 require 'simplecov'
 


### PR DESCRIPTION
This PR makes it easier to pursue the cause when unexpected values appear.


For example, when empty string is included in enum.

#### before this PR

`isn't include enum`

####  after this PR

`"" isn't include enum`
