### PR TITLE
Add collect_errors option

### DIFF
--- a/lib/openapi_parser/config.rb
+++ b/lib/openapi_parser/config.rb
@@ -23,11 +23,16 @@ class OpenAPIParser::Config
     @config.fetch(:validate_header, true)
   end
 
+  def collect_errors
+    @config.fetch(:collect_errors, false)
+  end
+
   # @return [OpenAPIParser::SchemaValidator::Options]
   def request_validator_options
     @request_validator_options ||= OpenAPIParser::SchemaValidator::Options.new(coerce_value: coerce_value,
                                                                                datetime_coerce_class: datetime_coerce_class,
-                                                                               validate_header: validate_header)
+                                                                               validate_header: validate_header,
+                                                                               collect_errors: collect_errors)
   end
 
   alias_method :request_body_options, :request_validator_options

--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -295,6 +295,10 @@ module OpenAPIParser
       @errors.each(&b)
     end
 
+    def merge(other, prefix: nil)
+      @errors.merge(other.errors, prefix: prefix)
+    end
+
     class Node
       attr_reader :children, :errors, :no_error, :passed_count
 
@@ -356,12 +360,19 @@ module OpenAPIParser
         @passed_count += 1
       end
 
-      def merge(other)
+      def merge(other, prefix: nil)
         @no_error ||= other. no_error
-        other.children.each do |key, child|
-          @children[key] = child
+        if prefix
+          node = self[prefix]
+        else
+          node = self
         end
-        @errors.concat other.errors
+        children = node.children
+        errors = node.errors
+        other.children.each do |key, child|
+          children[key] = child
+        end
+        errors.concat other.errors
       end
     end
   end

--- a/lib/openapi_parser/schema_validators/array_validator.rb
+++ b/lib/openapi_parser/schema_validators/array_validator.rb
@@ -10,8 +10,10 @@ class OpenAPIParser::SchemaValidator
 
       # array type have an schema in items property
       items_schema = schema.items
-      coerced_values = value.map do |v|
-        coerced, err = validatable.validate_schema(v, items_schema)
+      coerced_values = value.map.with_index do |v, i|
+        coerced, err = validatable.frame(i) do
+          validatable.validate_schema(v, items_schema)
+        end
         return [nil, err] if err
 
         coerced

--- a/lib/openapi_parser/schema_validators/one_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/one_of_validator.rb
@@ -8,8 +8,10 @@ class OpenAPIParser::SchemaValidator
       end
 
       # if multiple schemas are satisfied, it's not valid
-      result = schema.one_of.one? do |s|
-        _coerced, err = validatable.validate_schema(value, s)
+      result = schema.one_of.to_enum(:one?).with_index do |s, i|
+        _coerced, err = validatable.frame(i) do
+          validatable.validate_schema(value, s)
+        end
         err.nil?
       end
       if result

--- a/lib/openapi_parser/schema_validators/options.rb
+++ b/lib/openapi_parser/schema_validators/options.rb
@@ -6,12 +6,13 @@ class OpenAPIParser::SchemaValidator
     #   @return [Object, nil] coerce datetime string by this Object class
     # @!attribute [r] validate_header
     #   @return [Boolean] validate header or not
-    attr_reader :coerce_value, :datetime_coerce_class, :validate_header
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_header, :collect_errors
 
-    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true)
+    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true, collect_errors: false)
       @coerce_value = coerce_value
       @datetime_coerce_class = datetime_coerce_class
       @validate_header = validate_header
+      @collect_errors = collect_errors
     end
   end
 

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -619,6 +619,8 @@ components:
           type: string
         integer_1:
           type: integer
+        integer_2:
+          type: integer
       additionalProperties: false
     one_of_object2:
       type: object
@@ -629,5 +631,7 @@ components:
         name:
           type: string
         string_1:
+          type: string
+        string_2:
           type: string
       additionalProperties: false

--- a/spec/openapi_parser/parameter_validator_spec.rb
+++ b/spec/openapi_parser/parameter_validator_spec.rb
@@ -61,6 +61,22 @@ RSpec.describe OpenAPIParser::ParameterValidator do
           it { expect { subject }.to raise_error(OpenAPIParser::NotNullError) }
         end
       end
+
+      context 'collect_errors' do
+        let(:config) { { collect_errors: true } }
+        let(:params) { { 'query_integer_list' => nil, 'queryString' => 'Query' } }
+
+        it 'collects errors' do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::ErrorCollection)
+            expect(e.to_h).to match({
+              ["query_integer_list"] => an_instance_of(OpenAPIParser::NotNullError),
+              ["query_string"] => an_instance_of(OpenAPIParser::NotExistRequiredKey),
+            })
+            expect(e.message).to end_with('missing required parameters: query_string')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hello,

Thank you for developing a nice library.
I tried the library to validate the request body in my application and wanted to get a more detailed the errors.
The `openapi_parser` gem throws an exception immediately if an error is encountered, but I wanted to get the errors of the subsequent parameters as well.

So I added `collect_errors` option for `OpenAPIParser::SchemaValidator`.
How about a feature like this?
As long as we can achieve the same functionality, I don't care what form the implementation takes.