### PR TITLE
Updates error message for enums to be more readable

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -106,7 +106,7 @@ module OpenAPIParser
     end
 
     def message
-      "#{@value.inspect} isn't include enum in #{@reference}"
+      "#{@value.inspect} isn't part of the enum in #{@reference}"
     end
   end
 

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -242,14 +242,14 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         it 'not include enum' do
           expect { request_operation.validate_request_body(content_type, { 'enum_string' => 'x' }) }.to raise_error do |e|
             expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
-            expect(e.message.start_with?("\"x\" isn't include enum")).to eq true
+            expect(e.message.start_with?("\"x\" isn't part of the enum")).to eq true
           end
         end
 
         it 'not include enum (empty string)' do
           expect { request_operation.validate_request_body(content_type, { 'enum_string' => '' }) }.to raise_error do |e|
             expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
-            expect(e.message.start_with?("\"\" isn't include enum")).to eq true
+            expect(e.message.start_with?("\"\" isn't part of the enum")).to eq true
           end
         end
       end
@@ -265,7 +265,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         it 'not include enum' do
           expect { request_operation.validate_request_body(content_type, { 'enum_integer' => 3 }) }.to raise_error do |e|
             expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
-            expect(e.message.start_with?("3 isn't include enum")).to eq true
+            expect(e.message.start_with?("3 isn't part of the enum")).to eq true
           end
         end
       end
@@ -281,7 +281,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         it 'not include enum' do
           expect { request_operation.validate_request_body(content_type, { 'enum_number' => 1.1 }) }.to raise_error do |e|
             expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
-            expect(e.message.start_with?("1.1 isn't include enum")).to eq true
+            expect(e.message.start_with?("1.1 isn't part of the enum")).to eq true
           end
         end
       end


### PR DESCRIPTION
### What

It updates the error message for enums from
"{value} isn't include enum in {reference}"

to

"{value} isn't part of the enum in {reference}"