### PR TITLE
Add basic polymorphism handling

### DIFF
--- a/lib/openapi_parser/schema_validators/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validators/all_of_validator.rb
@@ -4,13 +4,18 @@ class OpenAPIParser::SchemaValidator
     # coerce and validate value
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
-    def coerce_and_validate(value, schema, **_keyword_args)
+    def coerce_and_validate(value, schema, **keyword_args)
       # if any schema return error, it's not valida all of value
       remaining_keys               = value.kind_of?(Hash) ? value.keys : []
       nested_additional_properties = false
       schema.all_of.each do |s|
         # We need to store the reference to all of, so we can perform strict check on allowed properties
-        _coerced, err = validatable.validate_schema(value, s, :parent_all_of => true)
+        _coerced, err = validatable.validate_schema(
+          value,
+          s,
+          :parent_all_of => true,
+          parent_discriminator_schemas: keyword_args[:parent_discriminator_schemas]
+        )
 
         if s.type == "object"
           remaining_keys               -= (s.properties || {}).keys

--- a/lib/openapi_parser/schema_validators/base.rb
+++ b/lib/openapi_parser/schema_validators/base.rb
@@ -18,7 +18,7 @@ class OpenAPIParser::SchemaValidator
       raise 'need implement'
     end
 
-    def validate_discriminator_schema(discriminator, value)
+    def validate_discriminator_schema(discriminator, value, parent_discriminator_schemas: [])
       unless value.key?(discriminator.property_name)
         return [nil, OpenAPIParser::NotExistDiscriminatorPropertyName.new(discriminator.property_name, value, discriminator.object_reference)]
       end
@@ -34,7 +34,11 @@ class OpenAPIParser::SchemaValidator
       unless resolved_schema
         return [nil, OpenAPIParser::NotExistDiscriminatorMappedSchema.new(mapping_target, discriminator.object_reference)]
       end
-      validatable.validate_schema(value, resolved_schema, **{discriminator_property_name: discriminator.property_name})
+      validatable.validate_schema(
+        value,
+        resolved_schema,
+        **{discriminator_property_name: discriminator.property_name, parent_discriminator_schemas: parent_discriminator_schemas}
+      )
     end
   end
 end

--- a/spec/data/petstore-with-mapped-polymorphism.yaml
+++ b/spec/data/petstore-with-mapped-polymorphism.yaml
@@ -1,9 +1,6 @@
----
 openapi: '3.0.3'
 info:
-  description: 'This is a sample server Petstore server.  You can find out more about
-    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
-    this sample, you can use the api key `special-key` to test the authorization filters.'
+  description: This is a sample server Petstore server.
   version: 1.0.5
   title: Swagger Petstore
   termsOfService: http://swagger.io/terms/
@@ -12,8 +9,6 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-host: petstore.swagger.io
-basePath: "/v2"
 tags:
 - name: pet
   description: Everything about your Pets
@@ -27,9 +22,6 @@ tags:
   externalDocs:
     description: Find out more about our store
     url: http://swagger.io
-schemes:
-- https
-- http
 paths:
   "/pet":
     post:
@@ -38,12 +30,6 @@ paths:
       summary: Add a new pet to the store
       description: ''
       operationId: addPet
-      consumes:
-      - application/json
-      - application/xml
-      produces:
-      - application/json
-      - application/xml
       requestBody:
         description: Pet object that needs to be added to the store
         required: true
@@ -60,19 +46,13 @@ paths:
       summary: Update an existing pet
       description: ''
       operationId: updatePet
-      consumes:
-      - application/json
-      - application/xml
-      produces:
-      - application/json
-      - application/xml
-      parameters:
-      - in: body
-        name: body
+      requestBody:
         description: Pet object that needs to be added to the store
         required: true
-        schema:
-          "$ref": "#/definitions/Pet"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
       responses:
         '400':
           description: Invalid ID supplied
@@ -80,10 +60,6 @@ paths:
           description: Pet not found
         '405':
           description: Validation exception
-      security:
-      - petstore_auth:
-        - write:pets
-        - read:pets
 components:
   schemas:
     Pet:

--- a/spec/data/petstore-with-mapped-polymorphism.yaml
+++ b/spec/data/petstore-with-mapped-polymorphism.yaml
@@ -1,0 +1,133 @@
+---
+swagger: '2.0'
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.5
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: "/v2"
+tags:
+- name: pet
+  description: Everything about your Pets
+  externalDocs:
+    description: Find out more
+    url: http://swagger.io
+- name: store
+  description: Access to Petstore orders
+- name: user
+  description: Operations about user
+  externalDocs:
+    description: Find out more about our store
+    url: http://swagger.io
+schemes:
+- https
+- http
+paths:
+  "/pet":
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      requestBody:
+        description: Pet object that needs to be added to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '405':
+          description: Invalid input
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: Pet object that needs to be added to the store
+        required: true
+        schema:
+          "$ref": "#/definitions/Pet"
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+        mapping:
+          tinyLion: '#/components/schemas/Cat'
+          docileWolf: '#/components/schemas/Dog'
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+      - name
+      - petType
+    Cat:  ## "Cat" will be used as the discriminator value
+      description: A representation of a cat
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          huntingSkill:
+            type: string
+            description: The measured skill for hunting
+            enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+        required:
+        - huntingSkill
+    Dog:  ## "Dog" will be used as the discriminator value
+      description: A representation of a dog
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          packSize:
+            type: integer
+            format: int32
+            description: the size of the pack the dog is from
+            default: 0
+            minimum: 0
+        required:
+        - packSize

--- a/spec/data/petstore-with-mapped-polymorphism.yaml
+++ b/spec/data/petstore-with-mapped-polymorphism.yaml
@@ -1,5 +1,5 @@
 ---
-swagger: '2.0'
+openapi: '3.0.3'
 info:
   description: 'This is a sample server Petstore server.  You can find out more about
     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For

--- a/spec/data/petstore-with-polymorphism.yaml
+++ b/spec/data/petstore-with-polymorphism.yaml
@@ -1,9 +1,6 @@
----
-swagger: '2.0'
+openapi: '3.0.3'
 info:
-  description: 'This is a sample server Petstore server.  You can find out more about
-    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
-    this sample, you can use the api key `special-key` to test the authorization filters.'
+  description: This is a sample server Petstore server.
   version: 1.0.5
   title: Swagger Petstore
   termsOfService: http://swagger.io/terms/
@@ -12,8 +9,6 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-host: petstore.swagger.io
-basePath: "/v2"
 tags:
 - name: pet
   description: Everything about your Pets
@@ -27,9 +22,6 @@ tags:
   externalDocs:
     description: Find out more about our store
     url: http://swagger.io
-schemes:
-- https
-- http
 paths:
   "/pet":
     post:
@@ -38,12 +30,6 @@ paths:
       summary: Add a new pet to the store
       description: ''
       operationId: addPet
-      consumes:
-      - application/json
-      - application/xml
-      produces:
-      - application/json
-      - application/xml
       requestBody:
         description: Pet object that needs to be added to the store
         required: true
@@ -60,19 +46,13 @@ paths:
       summary: Update an existing pet
       description: ''
       operationId: updatePet
-      consumes:
-      - application/json
-      - application/xml
-      produces:
-      - application/json
-      - application/xml
-      parameters:
-      - in: body
-        name: body
+      requestBody:
         description: Pet object that needs to be added to the store
         required: true
-        schema:
-          "$ref": "#/definitions/Pet"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
       responses:
         '400':
           description: Invalid ID supplied
@@ -80,10 +60,6 @@ paths:
           description: Pet not found
         '405':
           description: Validation exception
-      security:
-      - petstore_auth:
-        - write:pets
-        - read:pets
 components:
   schemas:
     Pet:

--- a/spec/data/petstore-with-polymorphism.yaml
+++ b/spec/data/petstore-with-polymorphism.yaml
@@ -1,0 +1,130 @@
+---
+swagger: '2.0'
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.5
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: "/v2"
+tags:
+- name: pet
+  description: Everything about your Pets
+  externalDocs:
+    description: Find out more
+    url: http://swagger.io
+- name: store
+  description: Access to Petstore orders
+- name: user
+  description: Operations about user
+  externalDocs:
+    description: Find out more about our store
+    url: http://swagger.io
+schemes:
+- https
+- http
+paths:
+  "/pet":
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      requestBody:
+        description: Pet object that needs to be added to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '405':
+          description: Invalid input
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: Pet object that needs to be added to the store
+        required: true
+        schema:
+          "$ref": "#/definitions/Pet"
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+      - name
+      - petType
+    Cat:  ## "Cat" will be used as the discriminator value
+      description: A representation of a cat
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          huntingSkill:
+            type: string
+            description: The measured skill for hunting
+            enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+        required:
+        - huntingSkill
+    Dog:  ## "Dog" will be used as the discriminator value
+      description: A representation of a dog
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          packSize:
+            type: integer
+            format: int32
+            description: the size of the pack the dog is from
+            default: 0
+            minimum: 0
+        required:
+        - packSize

--- a/spec/openapi_parser/schemas/polymorphism_spec.rb
+++ b/spec/openapi_parser/schemas/polymorphism_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../../spec_helper'
+
+RSpec.describe OpenAPIParser::Schemas::RequestBody do
+  let(:content_type) { 'application/json' }
+  let(:http_method) { :post }
+  let(:request_path) { '/pet' }
+  let(:request_operation) { root.request_operation(http_method, request_path) }
+  let(:params) { {} }
+
+  context 'whith discriminator with mapping' do
+    let(:root) { OpenAPIParser.parse(petstore_with_mapped_polymorphism_schema, {}) }
+
+    context 'with valid body' do
+      let(:body) do
+        {
+          "petType" => "Cat",
+          "name" => "Mr. Cat",
+          "huntingSkill" => "lazy"
+        }
+      end
+
+      it 'picks correct object based on mapping and succeeds' do
+        request_operation.validate_request_body(content_type, body)
+      end
+    end
+
+    context 'with body missing required value' do
+      let(:body) do
+        {
+          "petType" => "tinyLion",
+          "name" => "Mr. Cat"
+        }
+
+      end
+
+      it 'picks correct object based on mapping and fails' do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::NotExistRequiredKey)
+          expect(e.message).to end_with("missing required parameters: huntingSkill")
+        end
+      end
+    end
+
+    context 'with body containing unresolvable discriminator mapping' do
+      let(:body) do
+        {
+          "petType" => "coolCow",
+          "name" => "Ms. Cow"
+        }
+      end
+
+      it "throws error" do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorMappedSchema)).to eq true
+          expect(e.message).to match("^discriminator mapped schema #/components/schemas/coolCow does not exist.*?$")
+        end
+      end
+    end
+
+    context 'with body missing discriminator propertyName' do
+      let(:body) do
+        {
+          "name" => "Mr. Cat",
+          "huntingSkill" => "lazy"
+        }
+      end
+
+      it "throws error if discriminator propertyName is not present on object" do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorPropertyName)).to eq true
+          expect(e.message).to match("^discriminator propertyName petType does not exist in value.*?$")
+        end
+      end
+    end
+  end
+
+  describe 'discriminator without mapping' do
+    let(:root) { OpenAPIParser.parse(petstore_with_polymorphism_schema, {}) }
+
+    context 'with valid body' do
+      let(:body) do
+        {
+          "petType" => "Cat",
+          "name" => "Mr. Cat",
+          "huntingSkill" => "lazy"
+        }
+      end
+
+      it 'picks correct object based on mapping and succeeds' do
+        request_operation.validate_request_body(content_type, body)
+      end
+    end
+
+    context 'with body missing required value' do
+      let(:body) do
+        {
+          "petType" => "Cat",
+          "name" => "Mr. Cat"
+        }
+
+      end
+
+      it 'picks correct object based on mapping and fails' do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::NotExistRequiredKey)
+          expect(e.message).to end_with("missing required parameters: huntingSkill")
+        end
+      end
+    end
+
+    context 'with body containing unresolvable discriminator mapping' do
+      let(:body) do
+        {
+          "petType" => "Cow",
+          "name" => "Ms. Cow"
+        }
+      end
+
+      it "throws error" do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorMappedSchema)).to eq true
+          expect(e.message).to match("^discriminator mapped schema #/components/schemas/Cow does not exist.*?$")
+        end
+      end
+    end
+
+    context 'with body missing discriminator propertyName' do
+      let(:body) do
+        {
+          "name" => "Mr. Cat",
+          "huntingSkill" => "lazy"
+        }
+      end
+
+      it "throws error if discriminator propertyName is not present on object" do
+        expect { request_operation.validate_request_body(content_type, body) }.to raise_error do |e|
+          expect(e.kind_of?(OpenAPIParser::NotExistDiscriminatorPropertyName)).to eq true
+          expect(e.message).to match("^discriminator propertyName petType does not exist in value.*?$")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,14 @@ def petstore_with_discriminator_schema
   YAML.load_file('./spec/data/petstore-with-discriminator.yaml')
 end
 
+def petstore_with_mapped_polymorphism_schema
+  YAML.load_file('./spec/data/petstore-with-mapped-polymorphism.yaml')
+end
+
+def petstore_with_polymorphism_schema
+  YAML.load_file('./spec/data/petstore-with-polymorphism.yaml')
+end
+
 def json_petstore_schema_path
   './spec/data/petstore.json'
 end


### PR DESCRIPTION
This adds support for `discriminator` use without `oneOf` as described in the spec as [models with polymorphism support](http://spec.openapis.org/oas/v3.0.3#models-with-polymorphism-support). Hope I didn't create too much of a mess.