### PR TITLE
Support enum for booleans.

### DIFF
--- a/lib/openapi_parser/schema_validators/boolean_validator.rb
+++ b/lib/openapi_parser/schema_validators/boolean_validator.rb
@@ -1,5 +1,7 @@
 class OpenAPIParser::SchemaValidator
   class BooleanValidator < Base
+    include ::OpenAPIParser::SchemaValidator::Enumable
+
     TRUE_VALUES = ['true', '1'].freeze
     FALSE_VALUES = ['false', '0'].freeze
 
@@ -7,6 +9,9 @@ class OpenAPIParser::SchemaValidator
       value = coerce(value) if @coerce_value
 
       return OpenAPIParser::ValidateError.build_error_result(value, schema) unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
+
+      value, err = check_enum_include(value, schema)
+      return [nil, err] if err
 
       [value, nil]
     end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -314,6 +314,10 @@ paths:
                   enum:
                     - 1.0
                     - 2.1
+                enum_boolean:
+                  type: boolean
+                  enum:
+                    - true
 
       responses:
         '200':

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -285,6 +285,20 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           end
         end
       end
+
+      context 'enum boolean' do
+        it 'include enum' do
+          expect(request_operation.validate_request_body(content_type, { 'enum_boolean' => true })).
+            to eq({ 'enum_boolean' => true })
+        end
+
+        it 'not include enum' do
+          expect { request_operation.validate_request_body(content_type, { 'enum_boolean' => false }) }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
+            expect(e.message.start_with?("false isn't part of the enum")).to eq true
+          end
+        end
+      end
     end
 
     describe 'all_of' do
@@ -354,16 +368,16 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           }
         end
         let(:params) { correct_params }
-  
+
         it { expect(subject).not_to eq nil }
-  
+
         context 'no schema matched' do
           let(:params) do
             {
               'integer_1' => 42,
             }
           end
-  
+
           it do
             expect { subject }.to raise_error do |e|
               expect(e.kind_of?(OpenAPIParser::NotOneOf)).to eq true
@@ -371,7 +385,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
             end
           end
         end
-  
+
         context 'multiple schema matched' do
           let(:params) do
             {
@@ -380,14 +394,14 @@ RSpec.describe OpenAPIParser::SchemaValidator do
               'string_1' => 'string_1',
             }
           end
-  
+
           it do
             expect { subject }.to raise_error do |e|
               expect(e.kind_of?(OpenAPIParser::NotOneOf)).to eq true
               expect(e.message.include?("isn't one of")).to eq true
             end
           end
-        end  
+        end
       end
 
       context 'with discriminator' do
@@ -397,11 +411,11 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           {
             'objType' => 'obj1',
             'name' => 'name',
-            'integer_1' => 42,  
+            'integer_1' => 42,
           }
         end
         let(:params) { correct_params }
-  
+
         it { expect(subject).not_to eq nil }
       end
     end


### PR DESCRIPTION
If my reading of the spec is correct, `enum` should be supported for all data types, including booleans.

In our case, we are trying to specify that a boolean must have a specific value when constraining with a set of `oneOf` schemas. For example:
```
    ControlledDigitalLendingAccess:
      type: object
      properties:
        access:
          description: Access level.
          type: string
          enum:
            - stanford
        download:
          description: Download access level.
          type: string
          enum:
            - none
        readLocation:
          description: If access is "location-based", which location should have access.
          type: string
          nullable: true
          enum:
            - null
        controlledDigitalLending:
          description: Available for controlled digital lending.
          type: boolean
      required:
        - access
        - download
        - controlledDigitalLending
    StanfordAccess:
      type: object
      properties:
        access:
          description: Access level.
          type: string
          enum:
            - stanford
        download:
          description: Download access level.
          type: string
          enum:
            - stanford
        controlledDigitalLending:
          type: boolean
          enum:
            - false
    EmbargoAccess:
      type: object
      oneOf:
        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
        - $ref: '#/components/schemas/StanfordAccess'
```

That is, if satisfying the StanfordAccess schema, `controlledDigitalLending` must be false.