### PR TITLE
Support empty schema as any type

### DIFF
--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -12,6 +12,7 @@ require_relative 'schema_validators/any_of_validator'
 require_relative 'schema_validators/all_of_validator'
 require_relative 'schema_validators/one_of_validator'
 require_relative 'schema_validators/nil_validator'
+require_relative 'schema_validators/unspecified_type_validator'
 
 class OpenAPIParser::SchemaValidator
   # validate value by schema
@@ -113,7 +114,7 @@ class OpenAPIParser::SchemaValidator
       when 'array'
         array_validator
       else
-        nil
+        unspecified_type_validator
       end
     end
 
@@ -155,5 +156,9 @@ class OpenAPIParser::SchemaValidator
 
     def nil_validator
       @nil_validator ||= OpenAPIParser::SchemaValidator::NilValidator.new(self, @coerce_value)
+    end
+
+    def unspecified_type_validator
+      @unspecified_type_validator ||= OpenAPIParser::SchemaValidator::UnspecifiedTypeValidator.new(self, @coerce_value)
     end
 end

--- a/lib/openapi_parser/schema_validators/unspecified_type_validator.rb
+++ b/lib/openapi_parser/schema_validators/unspecified_type_validator.rb
@@ -1,0 +1,8 @@
+class OpenAPIParser::SchemaValidator
+  class UnspecifiedTypeValidator < Base
+    # @param [Object] value
+    def coerce_and_validate(value, _schema, **_keyword_args)
+      value
+    end
+  end
+end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -299,7 +299,7 @@ paths:
                     anyOf:
                       - type: string
                       - type: boolean
-                any_value: {}
+                unspecified_type: {}
                 enum_string:
                   type: string
                   enum:

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -299,6 +299,7 @@ paths:
                     anyOf:
                       - type: string
                       - type: boolean
+                any_value: {}
                 enum_string:
                   type: string
                   enum:

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -209,10 +209,10 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         end
       end
 
-      context 'any value' do
+      context 'unspecified_type' do
         it do
-          expect(request_operation.validate_request_body(content_type, { 'any_value' => "foo" })).
-            to eq({ 'any_value' => "foo" })
+          expect(request_operation.validate_request_body(content_type, { 'unspecified_type' => "foo" })).
+            to eq({ 'unspecified_type' => "foo" })
         end
       end
     end
@@ -431,20 +431,6 @@ RSpec.describe OpenAPIParser::SchemaValidator do
       expect { request_operation.validate_request_body(content_type, { 'unknown' => 1 }) }.to raise_error do |e|
         expect(e).to be_kind_of(OpenAPIParser::NotExistPropertyDefinition)
         expect(e.message).to end_with("does not define properties: unknown")
-      end
-    end
-
-    describe 'invalid type' do
-      let(:root) { OpenAPIParser.parse(invalid_schema, config) }
-      let(:invalid_schema) do
-        data = normal_schema
-        data['paths']['/validate']['post']['requestBody']['content']['application/json']['schema'].delete 'type'
-        data
-      end
-
-      it do
-        params = { 'string' => 'str' }
-        expect { request_operation.validate_request_body(content_type, params) }.to raise_error(OpenAPIParser::ValidateError)
       end
     end
   end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -208,6 +208,13 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           end
         end
       end
+
+      context 'any value' do
+        it do
+          expect(request_operation.validate_request_body(content_type, { 'any_value' => "foo" })).
+            to eq({ 'any_value' => "foo" })
+        end
+      end
     end
 
     describe 'object' do


### PR DESCRIPTION
The OpenAPI 3.0 spec (and the JSON schema spec it derives from) states that a schema without a type matches any data type, and that empty schemas are valid. This changes the parser to follow the spec.

See https://swagger.io/docs/specification/data-models/data-types/#any and https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.3.2

An alternative implementation here would be to treat an empty schema like an `anyOf` over all primitive types as the swagger.io page suggests. However, in that case we'd still need to support empty schema for the `array` and `object` possibilities within the `anyOf`, so the implementation in this PR seems more straightforward.