### PR TITLE
Fix anyOf coercion to float and integer when value is a non-string type

### DIFF
--- a/lib/openapi_parser/schema_validators/float_validator.rb
+++ b/lib/openapi_parser/schema_validators/float_validator.rb
@@ -21,14 +21,14 @@ class OpenAPIParser::SchemaValidator
 
         value, err = check_enum_include(value, schema)
         return [nil, err] if err
-        
+
         check_minimum_maximum(value, schema)
       end
 
       def coerce(value)
         Float(value)
-      rescue ArgumentError => e
-        raise e unless e.message =~ /invalid value for Float/
+      rescue ArgumentError, TypeError
+        value
       end
   end
 end

--- a/lib/openapi_parser/schema_validators/integer_validator.rb
+++ b/lib/openapi_parser/schema_validators/integer_validator.rb
@@ -23,12 +23,10 @@ class OpenAPIParser::SchemaValidator
         return value if value.kind_of?(Integer)
 
         begin
-          return Integer(value)
-        rescue ArgumentError => e
-          raise e unless e.message =~ /invalid value for Integer/
+          Integer(value)
+        rescue ArgumentError, TypeError
+          value
         end
-
-        value
       end
   end
 end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -133,6 +133,15 @@ paths:
           required: false
           schema:
             "$ref": '#/components/schemas/nested_array'
+        - name: any_of
+          in: query
+          description: coercing to any of types
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+              - type: number
+              - type: boolean
       responses:
         '200':
           description: success
@@ -150,6 +159,11 @@ paths:
             schema:
               type: object
               properties:
+                any_of:
+                  anyOf:
+                    - type: number
+                    - type: integer
+                    - type: boolean
                 nested_array:
                   "$ref": '#/components/schemas/nested_array'
       responses:

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -164,6 +164,7 @@ paths:
                     - type: number
                     - type: integer
                     - type: boolean
+                    - type: string
                 nested_array:
                   "$ref": '#/components/schemas/nested_array'
       responses:

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -537,6 +537,27 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           expect { subject }.to raise_error(OpenAPIParser::ValidateError)
         end
       end
+
+      context 'anyOf' do
+        where(:before_value, :result_value) do
+          [
+            [true, true],
+            ['true', true],
+            ['3.5', 3.5],
+            [3.5, 3.5],
+            [10, 10],
+            %w[pineapple pineapple]
+          ]
+        end
+
+        with_them do
+          let(:params) { { 'any_of' => before_value } }
+          it do
+            expect(subject).to eq({ 'any_of' => result_value })
+            expect(params['any_of']).to eq result_value
+          end
+        end
+      end
     end
 
     context 'string' do
@@ -781,6 +802,36 @@ RSpec.describe OpenAPIParser::SchemaValidator do
 
           expect(first_data['nested_coercer_object']['update_time'].class).to eq DateTime
           expect(first_data['nested_coercer_array'][0]['update_time'].class).to eq DateTime
+        end
+      end
+    end
+
+    context 'anyOf' do
+      let(:key) { 'any_of' }
+
+      context 'coerces valid values for any_of param' do
+        where(:before_value, :result_value) do
+          [
+            ['true', true],
+            ['3.5', 3.5],
+            ['10', 10]
+          ]
+        end
+
+        with_them do
+          let(:value) { before_value }
+          it do
+            expect(subject).to eq({ key.to_s => result_value })
+            expect(params[key]).to eq result_value
+          end
+        end
+      end
+
+      context 'invalid values' do
+        let(:value) { 'pineapple' }
+
+        it do
+          expect { subject }.to raise_error(OpenAPIParser::NotAnyOf)
         end
       end
     end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -546,6 +546,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
             ['3.5', 3.5],
             [3.5, 3.5],
             [10, 10],
+            ['10', 10],
             %w[pineapple pineapple]
           ]
         end


### PR DESCRIPTION
Found that attempting to coerce a non-string type (eg. boolean) to a float or integer caused a TypeError rather than an ArgumentError. This meant that `anyOf` had to be crafted so that numeric types were last to prevent a possible crash in certain situations.

This PR rescues the `TypeError` and causes the validator to behave as expected when the value cannot be coerced.