### PR TITLE
support: relative file path escape.

### DIFF
--- a/TAGS
+++ b/TAGS
@@ -1,0 +1,1352 @@
+
+lib/openapi_parser.rb,545
+module OpenAPIParserOpenAPIParser19,0
+    def parse(schema, config = {})parse23,0
+    def parse_with_filepath(schema, filepath, config = {})parse_with_filepath31,0
+    def load(filepath, config = {})load37,0
+    def load_uri(uri, config:, schema_registry:)load_uri43,0
+      def file_uri(filepath)file_uri58,0
+      def parse_file(content, extension)parse_file64,0
+      def parse_yaml(content)parse_yaml80,0
+      def parse_json(content)parse_json87,0
+      def load_hash(hash, config:, uri:, schema_registry:)load_hash91,0
+
+lib/openapi_parser/schema_validator.rb,1254
+class OpenAPIParser::SchemaValidatorSchemaValidator17,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator17,0
+  module ValidatableValidatable22,0
+  module ValidatableOpenAPIParser::SchemaValidator::Validatable22,0
+    def validate_schema(value, schema, **keyword_args)validate_schema23,0
+    def validate_integer(_value, _schema)validate_integer31,0
+    def validate(value, schema, options)validate44,0
+  def initialize(value, schema, options)initialize52,0
+  def validate_datavalidate_data61,0
+  def validate_schema(value, schema, **keyword_args)validate_schema71,0
+  def validate_integer(value, schema)validate_integer90,0
+    def validator(value, schema)validator97,0
+    def string_validatorstring_validator121,0
+    def integer_validatorinteger_validator125,0
+    def float_validatorfloat_validator129,0
+    def boolean_validatorboolean_validator133,0
+    def object_validatorobject_validator137,0
+    def array_validatorarray_validator141,0
+    def any_of_validatorany_of_validator145,0
+    def all_of_validatorall_of_validator149,0
+    def one_of_validatorone_of_validator153,0
+    def nil_validatornil_validator157,0
+    def unspecified_type_validatorunspecified_type_validator161,0
+
+lib/openapi_parser/config.rb,683
+class OpenAPIParser::ConfigConfig1,0
+class OpenAPIParser::ConfigOpenAPIParser::Config1,0
+  def initialize(config)initialize2,0
+  def datetime_coerce_classdatetime_coerce_class6,0
+  def coerce_valuecoerce_value10,0
+  def expand_referenceexpand_reference14,0
+  def strict_response_validationstrict_response_validation18,0
+  def validate_headervalidate_header22,0
+  def request_validator_optionsrequest_validator_options27,0
+  alias_method :request_body_options, :request_validator_optionsrequest_body_options33,0
+  alias_method :path_params_options, :request_validator_optionspath_params_options34,0
+  def response_validate_optionsresponse_validate_options37,0
+
+lib/openapi_parser/concerns/schema_loader/list_loader.rb,440
+class OpenAPIParser::SchemaLoader::ListLoader < OpenAPIParser::SchemaLoader::CreatorListLoader2,0
+class OpenAPIParser::SchemaLoader::ListLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::ListLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_list_object(target_object, array_schema)create_attr_list_object12,0
+    alias_method :ref_name_base, :schema_keyref_name_base27,0
+
+lib/openapi_parser/concerns/schema_loader/objects_loader.rb,372
+class OpenAPIParser::SchemaLoader::ObjectsLoader < OpenAPIParser::SchemaLoader::CreatorObjectsLoader2,0
+class OpenAPIParser::SchemaLoader::ObjectsLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::ObjectsLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_object(target_object, schema)create_attr_object14,0
+
+lib/openapi_parser/concerns/schema_loader/values_loader.rb,288
+class OpenAPIParser::SchemaLoader::ValuesLoader < OpenAPIParser::SchemaLoader::BaseValuesLoader2,0
+class OpenAPIParser::SchemaLoader::ValuesLoader < OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::ValuesLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+
+lib/openapi_parser/concerns/schema_loader/hash_body_loader.rb,495
+class OpenAPIParser::SchemaLoader::HashBodyLoader < OpenAPIParser::SchemaLoader::CreatorHashBodyLoader2,0
+class OpenAPIParser::SchemaLoader::HashBodyLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::HashBodyLoader2,0
+  def initialize(variable_name, options)initialize5,0
+  def load_data(target_object, raw_schema)load_data14,0
+    def create_hash_body_objects(target_object, raw_schema)create_hash_body_objects22,0
+    attr_reader :reject_keysreject_keys36,0
+
+lib/openapi_parser/concerns/schema_loader/base.rb,434
+class OpenAPIParser::SchemaLoader::BaseBase2,0
+class OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::Base2,0
+  def initialize(variable_name, options)initialize5,0
+  def load_data(_target_object, _raw_schema)load_data13,0
+    attr_reader :variable_name, :schema_keyvariable_name19,0
+    attr_reader :variable_name, :schema_keyschema_key19,0
+    def variable_set(target, variable_name, data)variable_set25,0
+
+lib/openapi_parser/concerns/schema_loader/hash_objects_loader.rb,467
+class OpenAPIParser::SchemaLoader::HashObjectsLoader < OpenAPIParser::SchemaLoader::CreatorHashObjectsLoader2,0
+class OpenAPIParser::SchemaLoader::HashObjectsLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::HashObjectsLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_hash_object(target_object, hash_schema)create_attr_hash_object12,0
+    alias_method :ref_name_base, :schema_keyref_name_base28,0
+
+lib/openapi_parser/concerns/schema_loader/creator.rb,892
+class OpenAPIParser::SchemaLoader::Creator < OpenAPIParser::SchemaLoader::BaseCreator2,0
+class OpenAPIParser::SchemaLoader::Creator < OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::Creator2,0
+  def initialize(variable_name, options)initialize5,0
+    attr_reader :klass, :allow_reference, :allow_data_typeklass15,0
+    attr_reader :klass, :allow_reference, :allow_data_typeallow_reference15,0
+    attr_reader :klass, :allow_reference, :allow_data_typeallow_data_type15,0
+    def build_object_reference_from_base(base, names)build_object_reference_from_base17,0
+    def check_reference_schema?(check_schema)check_reference_schema?25,0
+    def check_object_schema?(check_schema)check_object_schema?29,0
+    def escape_reference(str)escape_reference33,0
+    def build_openapi_object_from_option(target_object, ref, schema)build_openapi_object_from_option37,0
+
+lib/openapi_parser/concerns/parser.rb,2040
+module OpenAPIParser::ParserParser1,0
+module OpenAPIParser::ParserOpenAPIParser::Parser1,0
+module OpenAPIParser::ParserParser9,0
+module OpenAPIParser::ParserOpenAPIParser::Parser9,0
+  def self.included(base)included10,0
+  module ClassMethodsClassMethods13,0
+  module ClassMethodsOpenAPIParser::Parser::ClassMethods13,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_values_openapi_attr_values16,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_valuesopenapi_attr_value16,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_valuesopenapi_attr_values16,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_object_openapi_attr_objects17,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_objectopenapi_attr_objects17,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_objectopenapi_attr_object17,0
+    def_delegators :_parser_core, :_openapi_attr_list_objects, :openapi_attr_list_object_openapi_attr_list_objects18,0
+    def_delegators :_parser_core, :_openapi_attr_list_objects, :openapi_attr_list_objectopenapi_attr_list_object18,0
+    def_delegators :_parser_core, :_openapi_attr_hash_objects, :openapi_attr_hash_object_openapi_attr_hash_objects19,0
+    def_delegators :_parser_core, :_openapi_attr_hash_objects, :openapi_attr_hash_objectopenapi_attr_hash_object19,0
+    def_delegators :_parser_core, :_openapi_attr_hash_body_objects, :openapi_attr_hash_body_objects_openapi_attr_hash_body_objects20,0
+    def_delegators :_parser_core, :_openapi_attr_hash_body_objects, :openapi_attr_hash_body_objectsopenapi_attr_hash_body_objects20,0
+    def _parser_core_parser_core22,0
+  def _update_child_object(old, new)_update_child_object29,0
+  def _openapi_all_child_objects_openapi_all_child_objects34,0
+  def load_dataload_data40,0
+
+lib/openapi_parser/concerns/parameter_validatable.rb,803
+module OpenAPIParser::ParameterValidatableParameterValidatable1,0
+module OpenAPIParser::ParameterValidatableOpenAPIParser::ParameterValidatable1,0
+  def validate_path_params(path_params, options)validate_path_params4,0
+  def validate_request_parameter(params, headers, options)validate_request_parameter11,0
+  def set_parent_path_item(path_item)set_parent_path_item17,0
+    def validate_query_parameter(params, object_reference, options)validate_query_parameter27,0
+    def validate_header_parameter(headers, object_reference, options)validate_header_parameter34,0
+    def header_parameter_hashheader_parameter_hash38,0
+    def path_parameter_hashpath_parameter_hash42,0
+    def query_parameter_hashquery_parameter_hash46,0
+    def divided_parameter_hashdivided_parameter_hash51,0
+
+lib/openapi_parser/concerns/findable.rb,259
+module OpenAPIParser::FindableFindable4,0
+module OpenAPIParser::FindableOpenAPIParser::Findable4,0
+  def find_object(reference)find_object7,0
+  def purge_object_cachepurge_object_cache35,0
+    def find_remote_object(reference)find_remote_object48,0
+
+lib/openapi_parser/concerns/expandable.rb,569
+module OpenAPIParser::ExpandableExpandable1,0
+module OpenAPIParser::ExpandableOpenAPIParser::Expandable1,0
+  def expand_reference(root)expand_reference5,0
+    def expand_hash_objects(root, attribute_names)expand_hash_objects15,0
+    def expand_hash_attribute(root, name)expand_hash_attribute21,0
+    def expand_objects(root, attribute_names)expand_objects36,0
+    def expand_list_objects(root, attribute_names)expand_list_objects51,0
+    def expand_object(root, object)expand_object68,0
+    def referenced_object(root, reference)referenced_object79,0
+
+lib/openapi_parser/concerns/parser/value.rb,294
+module OpenAPIParser::Parser::ValueValue1,0
+module OpenAPIParser::Parser::ValueOpenAPIParser::Parser::Value1,0
+  def _openapi_attr_values_openapi_attr_values2,0
+  def openapi_attr_values(*names)openapi_attr_values6,0
+  def openapi_attr_value(name, options = {})openapi_attr_value10,0
+
+lib/openapi_parser/concerns/parser/object.rb,318
+module OpenAPIParser::Parser::ObjectObject1,0
+module OpenAPIParser::Parser::ObjectOpenAPIParser::Parser::Object1,0
+  def _openapi_attr_objects_openapi_attr_objects2,0
+  def openapi_attr_objects(*names, klass)openapi_attr_objects6,0
+  def openapi_attr_object(name, klass, options = {})openapi_attr_object10,0
+
+lib/openapi_parser/concerns/parser/hash.rb,262
+module OpenAPIParser::Parser::HashHash1,0
+module OpenAPIParser::Parser::HashOpenAPIParser::Parser::Hash1,0
+  def _openapi_attr_hash_objects_openapi_attr_hash_objects2,0
+  def openapi_attr_hash_object(name, klass, options = {})openapi_attr_hash_object6,0
+
+lib/openapi_parser/concerns/parser/core.rb,204
+class OpenAPIParser::Parser::CoreCore7,0
+class OpenAPIParser::Parser::CoreOpenAPIParser::Parser::Core7,0
+  def initialize(target_klass)initialize14,0
+    attr_reader :target_klasstarget_klass20,0
+
+lib/openapi_parser/concerns/parser/list.rb,262
+module OpenAPIParser::Parser::ListList1,0
+module OpenAPIParser::Parser::ListOpenAPIParser::Parser::List1,0
+  def _openapi_attr_list_objects_openapi_attr_list_objects2,0
+  def openapi_attr_list_object(name, klass, options = {})openapi_attr_list_object6,0
+
+lib/openapi_parser/concerns/parser/hash_body.rb,300
+module OpenAPIParser::Parser::HashBodyHashBody1,0
+module OpenAPIParser::Parser::HashBodyOpenAPIParser::Parser::HashBody1,0
+  def _openapi_attr_hash_body_objects_openapi_attr_hash_body_objects2,0
+  def openapi_attr_hash_body_objects(name, klass, options = {})openapi_attr_hash_body_objects6,0
+
+lib/openapi_parser/concerns/media_type_selectable.rb,244
+module OpenAPIParser::MediaTypeSelectableMediaTypeSelectable1,0
+module OpenAPIParser::MediaTypeSelectableOpenAPIParser::MediaTypeSelectable1,0
+    def select_media_type_from_content(content_type, content)select_media_type_from_content8,0
+
+lib/openapi_parser/concerns/schema_loader.rb,632
+class OpenAPIParser::SchemaLoaderSchemaLoader1,0
+class OpenAPIParser::SchemaLoaderOpenAPIParser::SchemaLoader1,0
+class OpenAPIParser::SchemaLoaderSchemaLoader13,0
+class OpenAPIParser::SchemaLoaderOpenAPIParser::SchemaLoader13,0
+  def initialize(target_object, core)initialize16,0
+  attr_reader :childrenchildren24,0
+  def load_dataload_data29,0
+    attr_reader :core, :target_objectcore36,0
+    attr_reader :core, :target_objecttarget_object36,0
+    def load_data_by_schema_loader(schema_loader)load_data_by_schema_loader39,0
+    def register_child(object)register_child45,0
+    def all_loaderall_loader51,0
+
+lib/openapi_parser/errors.rb,5558
+module OpenAPIParserOpenAPIParser1,0
+  class OpenAPIError < StandardErrorOpenAPIError2,0
+  class OpenAPIError < StandardErrorOpenAPIParser::OpenAPIError2,0
+    def initialize(reference)initialize3,0
+  class ValidateError < OpenAPIErrorValidateError8,0
+  class ValidateError < OpenAPIErrorOpenAPIParser::ValidateError8,0
+    def initialize(data, type, reference)initialize9,0
+    def messagemessage15,0
+      def build_error_result(value, schema)build_error_result23,0
+  class NotNullError < OpenAPIErrorNotNullError29,0
+  class NotNullError < OpenAPIErrorOpenAPIParser::NotNullError29,0
+    def messagemessage30,0
+  class NotExistRequiredKey < OpenAPIErrorNotExistRequiredKey35,0
+  class NotExistRequiredKey < OpenAPIErrorOpenAPIParser::NotExistRequiredKey35,0
+    def initialize(keys, reference)initialize36,0
+    def messagemessage41,0
+  class NotExistPropertyDefinition < OpenAPIErrorNotExistPropertyDefinition46,0
+  class NotExistPropertyDefinition < OpenAPIErrorOpenAPIParser::NotExistPropertyDefinition46,0
+    def initialize(keys, reference)initialize47,0
+    def messagemessage52,0
+  class NotExistDiscriminatorMappedSchema < OpenAPIErrorNotExistDiscriminatorMappedSchema57,0
+  class NotExistDiscriminatorMappedSchema < OpenAPIErrorOpenAPIParser::NotExistDiscriminatorMappedSchema57,0
+    def initialize(mapped_schema_reference, reference)initialize58,0
+    def messagemessage63,0
+  class NotExistDiscriminatorPropertyName < OpenAPIErrorNotExistDiscriminatorPropertyName68,0
+  class NotExistDiscriminatorPropertyName < OpenAPIErrorOpenAPIParser::NotExistDiscriminatorPropertyName68,0
+    def initialize(key, value, reference)initialize69,0
+    def messagemessage75,0
+  class NotOneOf < OpenAPIErrorNotOneOf80,0
+  class NotOneOf < OpenAPIErrorOpenAPIParser::NotOneOf80,0
+    def initialize(value, reference)initialize81,0
+    def messagemessage86,0
+  class NotAnyOf < OpenAPIErrorNotAnyOf91,0
+  class NotAnyOf < OpenAPIErrorOpenAPIParser::NotAnyOf91,0
+    def initialize(value, reference)initialize92,0
+    def messagemessage97,0
+  class NotEnumInclude < OpenAPIErrorNotEnumInclude102,0
+  class NotEnumInclude < OpenAPIErrorOpenAPIParser::NotEnumInclude102,0
+    def initialize(value, reference)initialize103,0
+    def messagemessage108,0
+  class LessThanMinimum < OpenAPIErrorLessThanMinimum113,0
+  class LessThanMinimum < OpenAPIErrorOpenAPIParser::LessThanMinimum113,0
+    def initialize(value, reference)initialize114,0
+    def messagemessage119,0
+  class LessThanExclusiveMinimum < OpenAPIErrorLessThanExclusiveMinimum124,0
+  class LessThanExclusiveMinimum < OpenAPIErrorOpenAPIParser::LessThanExclusiveMinimum124,0
+    def initialize(value, reference)initialize125,0
+    def messagemessage130,0
+  class MoreThanMaximum < OpenAPIErrorMoreThanMaximum135,0
+  class MoreThanMaximum < OpenAPIErrorOpenAPIParser::MoreThanMaximum135,0
+    def initialize(value, reference)initialize136,0
+    def messagemessage141,0
+  class MoreThanExclusiveMaximum < OpenAPIErrorMoreThanExclusiveMaximum146,0
+  class MoreThanExclusiveMaximum < OpenAPIErrorOpenAPIParser::MoreThanExclusiveMaximum146,0
+    def initialize(value, reference)initialize147,0
+    def messagemessage152,0
+  class InvalidPattern < OpenAPIErrorInvalidPattern157,0
+  class InvalidPattern < OpenAPIErrorOpenAPIParser::InvalidPattern157,0
+    def initialize(value, pattern, reference, example)initialize158,0
+    def messagemessage165,0
+  class InvalidEmailFormat < OpenAPIErrorInvalidEmailFormat170,0
+  class InvalidEmailFormat < OpenAPIErrorOpenAPIParser::InvalidEmailFormat170,0
+    def initialize(value, reference)initialize171,0
+    def messagemessage176,0
+  class InvalidUUIDFormat < OpenAPIErrorInvalidUUIDFormat181,0
+  class InvalidUUIDFormat < OpenAPIErrorOpenAPIParser::InvalidUUIDFormat181,0
+    def initialize(value, reference)initialize182,0
+    def messagemessage187,0
+  class InvalidDateFormat < OpenAPIErrorInvalidDateFormat192,0
+  class InvalidDateFormat < OpenAPIErrorOpenAPIParser::InvalidDateFormat192,0
+    def initialize(value, reference)initialize193,0
+    def messagemessage198,0
+  class NotExistStatusCodeDefinition < OpenAPIErrorNotExistStatusCodeDefinition203,0
+  class NotExistStatusCodeDefinition < OpenAPIErrorOpenAPIParser::NotExistStatusCodeDefinition203,0
+    def messagemessage204,0
+  class NotExistContentTypeDefinition < OpenAPIErrorNotExistContentTypeDefinition209,0
+  class NotExistContentTypeDefinition < OpenAPIErrorOpenAPIParser::NotExistContentTypeDefinition209,0
+    def messagemessage210,0
+  class MoreThanMaxLength < OpenAPIErrorMoreThanMaxLength215,0
+  class MoreThanMaxLength < OpenAPIErrorOpenAPIParser::MoreThanMaxLength215,0
+    def initialize(value, reference)initialize216,0
+    def messagemessage221,0
+  class LessThanMinLength < OpenAPIErrorLessThanMinLength226,0
+  class LessThanMinLength < OpenAPIErrorOpenAPIParser::LessThanMinLength226,0
+    def initialize(value, reference)initialize227,0
+    def messagemessage232,0
+  class MoreThanMaxItems < OpenAPIErrorMoreThanMaxItems237,0
+  class MoreThanMaxItems < OpenAPIErrorOpenAPIParser::MoreThanMaxItems237,0
+    def initialize(value, reference)initialize238,0
+    def messagemessage243,0
+  class LessThanMinItems < OpenAPIErrorLessThanMinItems248,0
+  class LessThanMinItems < OpenAPIErrorOpenAPIParser::LessThanMinItems248,0
+    def initialize(value, reference)initialize249,0
+    def messagemessage254,0
+
+lib/openapi_parser/reference_expander.rb,172
+class OpenAPIParser::ReferenceExpanderReferenceExpander1,0
+class OpenAPIParser::ReferenceExpanderOpenAPIParser::ReferenceExpander1,0
+    def expand(openapi)expand4,0
+
+lib/openapi_parser/schema_validators/object_validator.rb,420
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class ObjectValidator < BaseObjectValidator2,0
+  class ObjectValidator < BaseOpenAPIParser::SchemaValidator::ObjectValidator2,0
+    def coerce_and_validate(value, schema, parent_all_of: false, parent_discriminator_schemas: [], discriminator_property_name: nil)coerce_and_validate7,0
+
+lib/openapi_parser/schema_validators/string_validator.rb,916
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class StringValidator < BaseStringValidator2,0
+  class StringValidator < BaseOpenAPIParser::SchemaValidator::StringValidator2,0
+    def initialize(validator, coerce_value, datetime_coerce_class)initialize5,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate10,0
+      def coerce_date_time(value, schema)coerce_date_time42,0
+      def parse_date_time(value, schema)parse_date_time48,0
+      def pattern_validate(value, schema)pattern_validate59,0
+      def validate_max_min_length(value, schema)validate_max_min_length67,0
+      def validate_email_format(value, schema)validate_email_format74,0
+      def validate_uuid_format(value, schema)validate_uuid_format85,0
+      def validate_date_format(value, schema)validate_date_format93,0
+
+lib/openapi_parser/schema_validators/array_validator.rb,417
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class ArrayValidator < BaseArrayValidator2,0
+  class ArrayValidator < BaseOpenAPIParser::SchemaValidator::ArrayValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+    def validate_max_min_items(value, schema)validate_max_min_items25,0
+
+lib/openapi_parser/schema_validators/enumable.rb,288
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  module EnumableEnumable2,0
+  module EnumableOpenAPIParser::SchemaValidator::Enumable2,0
+    def check_enum_include(value, schema)check_enum_include6,0
+
+lib/openapi_parser/schema_validators/minimum_maximum.rb,366
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  module MinimumMaximumMinimumMaximum2,0
+  module MinimumMaximumOpenAPIParser::SchemaValidator::MinimumMaximum2,0
+    def check_minimum_maximum(value, schema)check_minimum_maximum6,0
+      def validate(value, schema)validate18,0
+
+lib/openapi_parser/schema_validators/boolean_validator.rb,713
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class BooleanValidator < BaseBooleanValidator2,0
+  class BooleanValidator < BaseOpenAPIParser::SchemaValidator::BooleanValidator2,0
+    TRUE_VALUES = ['true', '1'].freezeTRUE_VALUES5,0
+    TRUE_VALUES = ['true', '1'].freezeOpenAPIParser::SchemaValidator::BooleanValidator::TRUE_VALUES5,0
+    FALSE_VALUES = ['false', '0'].freezeFALSE_VALUES6,0
+    FALSE_VALUES = ['false', '0'].freezeOpenAPIParser::SchemaValidator::BooleanValidator::FALSE_VALUES6,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate8,0
+      def coerce(value)coerce21,0
+
+lib/openapi_parser/schema_validators/options.rb,945
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class OptionsOptions2,0
+  class OptionsOpenAPIParser::SchemaValidator::Options2,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headercoerce_value9,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headerdatetime_coerce_class9,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headervalidate_header9,0
+    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true)initialize11,0
+  class ResponseValidateOptionsResponseValidateOptions19,0
+  class ResponseValidateOptionsOpenAPIParser::SchemaValidator::ResponseValidateOptions19,0
+    attr_reader :strict, :validate_headerstrict22,0
+    attr_reader :strict, :validate_headervalidate_header22,0
+    def initialize(strict: false, validate_header: true)initialize24,0
+
+lib/openapi_parser/schema_validators/unspecified_type_validator.rb,384
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class UnspecifiedTypeValidator < BaseUnspecifiedTypeValidator2,0
+  class UnspecifiedTypeValidator < BaseOpenAPIParser::SchemaValidator::UnspecifiedTypeValidator2,0
+    def coerce_and_validate(value, _schema, **_keyword_args)coerce_and_validate4,0
+
+lib/openapi_parser/schema_validators/nil_validator.rb,335
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class NilValidator < BaseNilValidator2,0
+  class NilValidator < BaseOpenAPIParser::SchemaValidator::NilValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/base.rb,527
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class BaseBase2,0
+  class BaseOpenAPIParser::SchemaValidator::Base2,0
+    def initialize(validatable, coerce_value)initialize4,0
+    attr_reader :validatablevalidatable9,0
+    def coerce_and_validate(_value, _schema, **_keyword_args)coerce_and_validate17,0
+    def validate_discriminator_schema(discriminator, value, parent_discriminator_schemas: [])validate_discriminator_schema21,0
+
+lib/openapi_parser/schema_validators/one_of_validator.rb,343
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class OneOfValidator < BaseOneOfValidator2,0
+  class OneOfValidator < BaseOpenAPIParser::SchemaValidator::OneOfValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/any_of_validator.rb,343
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class AnyOfValidator < BaseAnyOfValidator2,0
+  class AnyOfValidator < BaseOpenAPIParser::SchemaValidator::AnyOfValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/float_validator.rb,467
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class FloatValidator < BaseFloatValidator2,0
+  class FloatValidator < BaseOpenAPIParser::SchemaValidator::FloatValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate9,0
+      def coercer_and_validate_numeric(value, schema)coercer_and_validate_numeric19,0
+      def coerce(value)coerce28,0
+
+lib/openapi_parser/schema_validators/integer_validator.rb,387
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class IntegerValidator < BaseIntegerValidator2,0
+  class IntegerValidator < BaseOpenAPIParser::SchemaValidator::IntegerValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate9,0
+      def coerce(value)coerce22,0
+
+lib/openapi_parser/schema_validators/all_of_validator.rb,342
+class OpenAPIParser::SchemaValidatorSchemaValidator2,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator2,0
+  class AllOfValidator < BaseAllOfValidator3,0
+  class AllOfValidator < BaseOpenAPIParser::SchemaValidator::AllOfValidator3,0
+    def coerce_and_validate(value, schema, **keyword_args)coerce_and_validate7,0
+
+lib/openapi_parser/parameter_validator.rb,313
+class OpenAPIParser::ParameterValidatorParameterValidator1,0
+class OpenAPIParser::ParameterValidatorOpenAPIParser::ParameterValidator1,0
+    def validate_parameter(parameters_hash, params, object_reference, options, is_header = false)validate_parameter8,0
+    def convert_key(k, is_header)convert_key29,0
+
+lib/openapi_parser/path_item_finder.rb,1644
+class OpenAPIParser::PathItemFinderPathItemFinder1,0
+class OpenAPIParser::PathItemFinderOpenAPIParser::PathItemFinder1,0
+  def initialize(paths)initialize3,0
+  def operation_object(http_method, request_path)operation_object11,0
+  class ResultResult22,0
+  class ResultOpenAPIParser::PathItemFinder::Result22,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramspath_item_object23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramsoperation_object23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramsoriginal_path23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramspath_params23,0
+    def initialize(path_item_object, operation_object, original_path, path_params)initialize33,0
+  def parse_path_parameters(schema_path, request_path)parse_path_parameters41,0
+    def path_parameters(schema_path)path_parameters66,0
+    def matches_directly?(request_path, http_method)matches_directly?77,0
+    def different_depth_or_method?(splitted_schema_path, splitted_request_path, path_item, http_method)different_depth_or_method?82,0
+    def path_template?(schema_path_item)path_template?88,0
+    def param_name(schema_path_item)param_name94,0
+    def extract_params(splitted_request_path, splitted_schema_path)extract_params103,0
+    def matching_paths_with_params(request_path, http_method)matching_paths_with_params124,0
+    def find_path_and_params(http_method, request_path)find_path_and_params141,0
+    def parse_request_path(http_method, request_path)parse_request_path151,0
+
+lib/openapi_parser/version.rb,144
+module OpenAPIParserOpenAPIParser1,0
+  VERSION = '1.0.0.beta1'.freezeVERSION2,0
+  VERSION = '1.0.0.beta1'.freezeOpenAPIParser::VERSION2,0
+
+lib/openapi_parser/request_operation.rb,1800
+class OpenAPIParser::RequestOperationRequestOperation3,0
+class OpenAPIParser::RequestOperationOpenAPIParser::RequestOperation3,0
+    def create(http_method, request_path, path_item_finder, config)create8,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemoperation_object28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itempath_params28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemconfig28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemhttp_method28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemoriginal_path28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itempath_item28,0
+  def initialize(http_method, result, config)initialize33,0
+  def validate_path_params(options = nil)validate_path_params42,0
+  def validate_request_body(content_type, params, options = nil)validate_request_body50,0
+  def validate_response_body(response_body, response_validate_options = nil)validate_response_body57,0
+  def validate_request_parameter(params, headers, options = nil)validate_request_parameter66,0
+  class ValidatableResponseBodyValidatableResponseBody71,0
+  class ValidatableResponseBodyOpenAPIParser::RequestOperation::ValidatableResponseBody71,0
+    attr_reader :status_code, :response_data, :headersstatus_code72,0
+    attr_reader :status_code, :response_data, :headersresponse_data72,0
+    attr_reader :status_code, :response_data, :headersheaders72,0
+    def initialize(status_code, response_data, headers)initialize74,0
+    def content_typecontent_type80,0
+
+lib/openapi_parser/schemas/paths.rb,185
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Paths < BasePaths2,0
+  class Paths < BaseOpenAPIParser::Schemas::Paths2,0
+
+lib/openapi_parser/schemas/media_type.rb,269
+module OpenAPIParser::SchemasSchemas5,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas5,0
+  class MediaType < BaseMediaType6,0
+  class MediaType < BaseOpenAPIParser::Schemas::MediaType6,0
+    def validate_parameter(params, options)validate_parameter14,0
+
+lib/openapi_parser/schemas/operation.rb,380
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class Operation < BaseOperation7,0
+  class Operation < BaseOpenAPIParser::Schemas::Operation7,0
+    def validate_request_body(content_type, params, options)validate_request_body24,0
+    def validate_response(response_body, response_validate_options)validate_response30,0
+
+lib/openapi_parser/schemas/response.rb,398
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Response < BaseResponse4,0
+  class Response < BaseOpenAPIParser::Schemas::Response4,0
+    def validate(response_body, response_validate_options)validate19,0
+    def select_media_type(content_type)select_media_type36,0
+      def validate_header(response_headers)validate_header43,0
+
+lib/openapi_parser/schemas/discriminator.rb,217
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Discriminator < BaseDiscriminator2,0
+  class Discriminator < BaseOpenAPIParser::Schemas::Discriminator2,0
+
+lib/openapi_parser/schemas/path_item.rb,305
+module OpenAPIParser::SchemasSchemas4,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas4,0
+  class PathItem < BasePathItem5,0
+  class PathItem < BaseOpenAPIParser::Schemas::PathItem5,0
+    def operation(method)operation12,0
+    def set_path_item_to_operationset_path_item_to_operation18,0
+
+lib/openapi_parser/schemas/openapi.rb,456
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class OpenAPI < BaseOpenAPI7,0
+  class OpenAPI < BaseOpenAPIParser::Schemas::OpenAPI7,0
+    def initialize(raw_schema, config, uri: nil, schema_registry: {})initialize8,0
+    def request_operation(http_method, request_path)request_operation33,0
+    def load_another_schema(uri)load_another_schema39,0
+      def resolve_uri(uri)resolve_uri51,0
+
+lib/openapi_parser/schemas/responses.rb,422
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Responses < BaseResponses4,0
+  class Responses < BaseOpenAPIParser::Schemas::Responses4,0
+    def validate(response_body, response_validate_options)validate18,0
+      def find_response_object(status_code)find_response_object35,0
+      def status_code_to_wild_card(status_code)status_code_to_wild_card51,0
+
+lib/openapi_parser/schemas/header.rb,227
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Header < BaseHeader2,0
+  class Header < BaseOpenAPIParser::Schemas::Header2,0
+    def validate(value)validate14,0
+
+lib/openapi_parser/schemas/base.rb,618
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class BaseBase2,0
+  class BaseOpenAPIParser::Schemas::Base2,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootparent7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootraw_schema7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootobject_reference7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootroot7,0
+    def initialize(object_reference, parent, root, raw_schema)initialize10,0
+    def after_initafter_init21,0
+    def inspectinspect24,0
+
+lib/openapi_parser/schemas/schema.rb,247
+module OpenAPIParser::SchemasSchemas5,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas5,0
+  class Schema < BaseSchema6,0
+  class Schema < BaseOpenAPIParser::Schemas::Schema6,0
+    def additional_propertiesadditional_properties113,0
+
+lib/openapi_parser/schemas/reference.rb,201
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Reference < BaseReference2,0
+  class Reference < BaseOpenAPIParser::Schemas::Reference2,0
+
+lib/openapi_parser/schemas/parameter.rb,263
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Parameter < BaseParameter4,0
+  class Parameter < BaseOpenAPIParser::Schemas::Parameter4,0
+    def validate_params(params, options)validate_params16,0
+
+lib/openapi_parser/schemas/classes.rb,1735
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Base; endBase4,0
+  class Base; endOpenAPIParser::Schemas::Base4,0
+  class Discriminator < Base; endDiscriminator5,0
+  class Discriminator < Base; endOpenAPIParser::Schemas::Discriminator5,0
+  class OpenAPI < Base; endOpenAPI6,0
+  class OpenAPI < Base; endOpenAPIParser::Schemas::OpenAPI6,0
+  class Operation < Base; endOperation7,0
+  class Operation < Base; endOpenAPIParser::Schemas::Operation7,0
+  class Parameter < Base; endParameter8,0
+  class Parameter < Base; endOpenAPIParser::Schemas::Parameter8,0
+  class PathItem < Base; endPathItem9,0
+  class PathItem < Base; endOpenAPIParser::Schemas::PathItem9,0
+  class Paths < Base; endPaths10,0
+  class Paths < Base; endOpenAPIParser::Schemas::Paths10,0
+  class Reference < Base; endReference11,0
+  class Reference < Base; endOpenAPIParser::Schemas::Reference11,0
+  class RequestBody < Base; endRequestBody12,0
+  class RequestBody < Base; endOpenAPIParser::Schemas::RequestBody12,0
+  class Responses < Base; endResponses13,0
+  class Responses < Base; endOpenAPIParser::Schemas::Responses13,0
+  class Response < Base; endResponse14,0
+  class Response < Base; endOpenAPIParser::Schemas::Response14,0
+  class MediaType < Base; endMediaType15,0
+  class MediaType < Base; endOpenAPIParser::Schemas::MediaType15,0
+  class Schema < Base; endSchema16,0
+  class Schema < Base; endOpenAPIParser::Schemas::Schema16,0
+  class Components < Base; endComponents17,0
+  class Components < Base; endOpenAPIParser::Schemas::Components17,0
+  class Header < Base; endHeader18,0
+  class Header < Base; endOpenAPIParser::Schemas::Header18,0
+
+lib/openapi_parser/schemas/request_body.rb,360
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class RequestBody < BaseRequestBody4,0
+  class RequestBody < BaseOpenAPIParser::Schemas::RequestBody4,0
+    def validate_request_body(content_type, params, options)validate_request_body20,0
+    def select_media_type(content_type)select_media_type30,0
+
+lib/openapi_parser/schemas/components.rb,205
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class Components < BaseComponents7,0
+  class Components < BaseOpenAPIParser::Schemas::Components7,0
+
+spec/spec_helper.rb,1786
+def load_yaml_file(path)load_yaml_file27,0
+def normal_schemanormal_schema31,0
+def petstore_schemapetstore_schema35,0
+def petstore_schema_pathpetstore_schema_path39,0
+def petstore_with_discriminator_schemapetstore_with_discriminator_schema43,0
+def petstore_with_mapped_polymorphism_schemapetstore_with_mapped_polymorphism_schema47,0
+def petstore_with_polymorphism_schemapetstore_with_polymorphism_schema51,0
+def json_petstore_schema_pathjson_petstore_schema_path55,0
+def json_with_unsupported_extension_petstore_schema_pathjson_with_unsupported_extension_petstore_schema_path59,0
+def yaml_with_unsupported_extension_petstore_schema_pathyaml_with_unsupported_extension_petstore_schema_path63,0
+def path_item_ref_schemapath_item_ref_schema67,0
+def build_validate_test_schema(new_properties)build_validate_test_schema71,0
+def change_string_key(hash)change_string_key78,0
+def load_yaml_file(path)load_yaml_file27,0
+def normal_schemanormal_schema31,0
+def petstore_schemapetstore_schema35,0
+def petstore_schema_pathpetstore_schema_path39,0
+def petstore_with_discriminator_schemapetstore_with_discriminator_schema43,0
+def petstore_with_mapped_polymorphism_schemapetstore_with_mapped_polymorphism_schema47,0
+def petstore_with_polymorphism_schemapetstore_with_polymorphism_schema51,0
+def json_petstore_schema_pathjson_petstore_schema_path55,0
+def json_with_unsupported_extension_petstore_schema_pathjson_with_unsupported_extension_petstore_schema_path59,0
+def yaml_with_unsupported_extension_petstore_schema_pathyaml_with_unsupported_extension_petstore_schema_path63,0
+def path_item_ref_schemapath_item_ref_schema67,0
+def build_validate_test_schema(new_properties)build_validate_test_schema71,0
+def change_string_key(hash)change_string_key78,0
+
+lib/openapi_parser.rb,545
+module OpenAPIParserOpenAPIParser19,0
+    def parse(schema, config = {})parse23,0
+    def parse_with_filepath(schema, filepath, config = {})parse_with_filepath31,0
+    def load(filepath, config = {})load37,0
+    def load_uri(uri, config:, schema_registry:)load_uri43,0
+      def file_uri(filepath)file_uri58,0
+      def parse_file(content, extension)parse_file64,0
+      def parse_yaml(content)parse_yaml80,0
+      def parse_json(content)parse_json87,0
+      def load_hash(hash, config:, uri:, schema_registry:)load_hash91,0
+
+lib/openapi_parser/schema_validator.rb,1254
+class OpenAPIParser::SchemaValidatorSchemaValidator17,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator17,0
+  module ValidatableValidatable22,0
+  module ValidatableOpenAPIParser::SchemaValidator::Validatable22,0
+    def validate_schema(value, schema, **keyword_args)validate_schema23,0
+    def validate_integer(_value, _schema)validate_integer31,0
+    def validate(value, schema, options)validate44,0
+  def initialize(value, schema, options)initialize52,0
+  def validate_datavalidate_data61,0
+  def validate_schema(value, schema, **keyword_args)validate_schema71,0
+  def validate_integer(value, schema)validate_integer90,0
+    def validator(value, schema)validator97,0
+    def string_validatorstring_validator121,0
+    def integer_validatorinteger_validator125,0
+    def float_validatorfloat_validator129,0
+    def boolean_validatorboolean_validator133,0
+    def object_validatorobject_validator137,0
+    def array_validatorarray_validator141,0
+    def any_of_validatorany_of_validator145,0
+    def all_of_validatorall_of_validator149,0
+    def one_of_validatorone_of_validator153,0
+    def nil_validatornil_validator157,0
+    def unspecified_type_validatorunspecified_type_validator161,0
+
+lib/openapi_parser/config.rb,683
+class OpenAPIParser::ConfigConfig1,0
+class OpenAPIParser::ConfigOpenAPIParser::Config1,0
+  def initialize(config)initialize2,0
+  def datetime_coerce_classdatetime_coerce_class6,0
+  def coerce_valuecoerce_value10,0
+  def expand_referenceexpand_reference14,0
+  def strict_response_validationstrict_response_validation18,0
+  def validate_headervalidate_header22,0
+  def request_validator_optionsrequest_validator_options27,0
+  alias_method :request_body_options, :request_validator_optionsrequest_body_options33,0
+  alias_method :path_params_options, :request_validator_optionspath_params_options34,0
+  def response_validate_optionsresponse_validate_options37,0
+
+lib/openapi_parser/concerns/schema_loader/list_loader.rb,440
+class OpenAPIParser::SchemaLoader::ListLoader < OpenAPIParser::SchemaLoader::CreatorListLoader2,0
+class OpenAPIParser::SchemaLoader::ListLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::ListLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_list_object(target_object, array_schema)create_attr_list_object12,0
+    alias_method :ref_name_base, :schema_keyref_name_base27,0
+
+lib/openapi_parser/concerns/schema_loader/objects_loader.rb,372
+class OpenAPIParser::SchemaLoader::ObjectsLoader < OpenAPIParser::SchemaLoader::CreatorObjectsLoader2,0
+class OpenAPIParser::SchemaLoader::ObjectsLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::ObjectsLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_object(target_object, schema)create_attr_object14,0
+
+lib/openapi_parser/concerns/schema_loader/values_loader.rb,288
+class OpenAPIParser::SchemaLoader::ValuesLoader < OpenAPIParser::SchemaLoader::BaseValuesLoader2,0
+class OpenAPIParser::SchemaLoader::ValuesLoader < OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::ValuesLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+
+lib/openapi_parser/concerns/schema_loader/hash_body_loader.rb,495
+class OpenAPIParser::SchemaLoader::HashBodyLoader < OpenAPIParser::SchemaLoader::CreatorHashBodyLoader2,0
+class OpenAPIParser::SchemaLoader::HashBodyLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::HashBodyLoader2,0
+  def initialize(variable_name, options)initialize5,0
+  def load_data(target_object, raw_schema)load_data14,0
+    def create_hash_body_objects(target_object, raw_schema)create_hash_body_objects22,0
+    attr_reader :reject_keysreject_keys36,0
+
+lib/openapi_parser/concerns/schema_loader/base.rb,434
+class OpenAPIParser::SchemaLoader::BaseBase2,0
+class OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::Base2,0
+  def initialize(variable_name, options)initialize5,0
+  def load_data(_target_object, _raw_schema)load_data13,0
+    attr_reader :variable_name, :schema_keyvariable_name19,0
+    attr_reader :variable_name, :schema_keyschema_key19,0
+    def variable_set(target, variable_name, data)variable_set25,0
+
+lib/openapi_parser/concerns/schema_loader/hash_objects_loader.rb,467
+class OpenAPIParser::SchemaLoader::HashObjectsLoader < OpenAPIParser::SchemaLoader::CreatorHashObjectsLoader2,0
+class OpenAPIParser::SchemaLoader::HashObjectsLoader < OpenAPIParser::SchemaLoader::CreatorOpenAPIParser::SchemaLoader::HashObjectsLoader2,0
+  def load_data(target_object, raw_schema)load_data6,0
+    def create_attr_hash_object(target_object, hash_schema)create_attr_hash_object12,0
+    alias_method :ref_name_base, :schema_keyref_name_base28,0
+
+lib/openapi_parser/concerns/schema_loader/creator.rb,892
+class OpenAPIParser::SchemaLoader::Creator < OpenAPIParser::SchemaLoader::BaseCreator2,0
+class OpenAPIParser::SchemaLoader::Creator < OpenAPIParser::SchemaLoader::BaseOpenAPIParser::SchemaLoader::Creator2,0
+  def initialize(variable_name, options)initialize5,0
+    attr_reader :klass, :allow_reference, :allow_data_typeklass15,0
+    attr_reader :klass, :allow_reference, :allow_data_typeallow_reference15,0
+    attr_reader :klass, :allow_reference, :allow_data_typeallow_data_type15,0
+    def build_object_reference_from_base(base, names)build_object_reference_from_base17,0
+    def check_reference_schema?(check_schema)check_reference_schema?25,0
+    def check_object_schema?(check_schema)check_object_schema?29,0
+    def escape_reference(str)escape_reference33,0
+    def build_openapi_object_from_option(target_object, ref, schema)build_openapi_object_from_option37,0
+
+lib/openapi_parser/concerns/parser.rb,2040
+module OpenAPIParser::ParserParser1,0
+module OpenAPIParser::ParserOpenAPIParser::Parser1,0
+module OpenAPIParser::ParserParser9,0
+module OpenAPIParser::ParserOpenAPIParser::Parser9,0
+  def self.included(base)included10,0
+  module ClassMethodsClassMethods13,0
+  module ClassMethodsOpenAPIParser::Parser::ClassMethods13,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_values_openapi_attr_values16,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_valuesopenapi_attr_value16,0
+    def_delegators :_parser_core, :_openapi_attr_values, :openapi_attr_value, :openapi_attr_valuesopenapi_attr_values16,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_object_openapi_attr_objects17,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_objectopenapi_attr_objects17,0
+    def_delegators :_parser_core, :_openapi_attr_objects, :openapi_attr_objects, :openapi_attr_objectopenapi_attr_object17,0
+    def_delegators :_parser_core, :_openapi_attr_list_objects, :openapi_attr_list_object_openapi_attr_list_objects18,0
+    def_delegators :_parser_core, :_openapi_attr_list_objects, :openapi_attr_list_objectopenapi_attr_list_object18,0
+    def_delegators :_parser_core, :_openapi_attr_hash_objects, :openapi_attr_hash_object_openapi_attr_hash_objects19,0
+    def_delegators :_parser_core, :_openapi_attr_hash_objects, :openapi_attr_hash_objectopenapi_attr_hash_object19,0
+    def_delegators :_parser_core, :_openapi_attr_hash_body_objects, :openapi_attr_hash_body_objects_openapi_attr_hash_body_objects20,0
+    def_delegators :_parser_core, :_openapi_attr_hash_body_objects, :openapi_attr_hash_body_objectsopenapi_attr_hash_body_objects20,0
+    def _parser_core_parser_core22,0
+  def _update_child_object(old, new)_update_child_object29,0
+  def _openapi_all_child_objects_openapi_all_child_objects34,0
+  def load_dataload_data40,0
+
+lib/openapi_parser/concerns/parameter_validatable.rb,803
+module OpenAPIParser::ParameterValidatableParameterValidatable1,0
+module OpenAPIParser::ParameterValidatableOpenAPIParser::ParameterValidatable1,0
+  def validate_path_params(path_params, options)validate_path_params4,0
+  def validate_request_parameter(params, headers, options)validate_request_parameter11,0
+  def set_parent_path_item(path_item)set_parent_path_item17,0
+    def validate_query_parameter(params, object_reference, options)validate_query_parameter27,0
+    def validate_header_parameter(headers, object_reference, options)validate_header_parameter34,0
+    def header_parameter_hashheader_parameter_hash38,0
+    def path_parameter_hashpath_parameter_hash42,0
+    def query_parameter_hashquery_parameter_hash46,0
+    def divided_parameter_hashdivided_parameter_hash51,0
+
+lib/openapi_parser/concerns/findable.rb,259
+module OpenAPIParser::FindableFindable4,0
+module OpenAPIParser::FindableOpenAPIParser::Findable4,0
+  def find_object(reference)find_object7,0
+  def purge_object_cachepurge_object_cache35,0
+    def find_remote_object(reference)find_remote_object48,0
+
+lib/openapi_parser/concerns/expandable.rb,569
+module OpenAPIParser::ExpandableExpandable1,0
+module OpenAPIParser::ExpandableOpenAPIParser::Expandable1,0
+  def expand_reference(root)expand_reference5,0
+    def expand_hash_objects(root, attribute_names)expand_hash_objects15,0
+    def expand_hash_attribute(root, name)expand_hash_attribute21,0
+    def expand_objects(root, attribute_names)expand_objects36,0
+    def expand_list_objects(root, attribute_names)expand_list_objects51,0
+    def expand_object(root, object)expand_object68,0
+    def referenced_object(root, reference)referenced_object79,0
+
+lib/openapi_parser/concerns/parser/value.rb,294
+module OpenAPIParser::Parser::ValueValue1,0
+module OpenAPIParser::Parser::ValueOpenAPIParser::Parser::Value1,0
+  def _openapi_attr_values_openapi_attr_values2,0
+  def openapi_attr_values(*names)openapi_attr_values6,0
+  def openapi_attr_value(name, options = {})openapi_attr_value10,0
+
+lib/openapi_parser/concerns/parser/object.rb,318
+module OpenAPIParser::Parser::ObjectObject1,0
+module OpenAPIParser::Parser::ObjectOpenAPIParser::Parser::Object1,0
+  def _openapi_attr_objects_openapi_attr_objects2,0
+  def openapi_attr_objects(*names, klass)openapi_attr_objects6,0
+  def openapi_attr_object(name, klass, options = {})openapi_attr_object10,0
+
+lib/openapi_parser/concerns/parser/hash.rb,262
+module OpenAPIParser::Parser::HashHash1,0
+module OpenAPIParser::Parser::HashOpenAPIParser::Parser::Hash1,0
+  def _openapi_attr_hash_objects_openapi_attr_hash_objects2,0
+  def openapi_attr_hash_object(name, klass, options = {})openapi_attr_hash_object6,0
+
+lib/openapi_parser/concerns/parser/core.rb,204
+class OpenAPIParser::Parser::CoreCore7,0
+class OpenAPIParser::Parser::CoreOpenAPIParser::Parser::Core7,0
+  def initialize(target_klass)initialize14,0
+    attr_reader :target_klasstarget_klass20,0
+
+lib/openapi_parser/concerns/parser/list.rb,262
+module OpenAPIParser::Parser::ListList1,0
+module OpenAPIParser::Parser::ListOpenAPIParser::Parser::List1,0
+  def _openapi_attr_list_objects_openapi_attr_list_objects2,0
+  def openapi_attr_list_object(name, klass, options = {})openapi_attr_list_object6,0
+
+lib/openapi_parser/concerns/parser/hash_body.rb,300
+module OpenAPIParser::Parser::HashBodyHashBody1,0
+module OpenAPIParser::Parser::HashBodyOpenAPIParser::Parser::HashBody1,0
+  def _openapi_attr_hash_body_objects_openapi_attr_hash_body_objects2,0
+  def openapi_attr_hash_body_objects(name, klass, options = {})openapi_attr_hash_body_objects6,0
+
+lib/openapi_parser/concerns/media_type_selectable.rb,244
+module OpenAPIParser::MediaTypeSelectableMediaTypeSelectable1,0
+module OpenAPIParser::MediaTypeSelectableOpenAPIParser::MediaTypeSelectable1,0
+    def select_media_type_from_content(content_type, content)select_media_type_from_content8,0
+
+lib/openapi_parser/concerns/schema_loader.rb,632
+class OpenAPIParser::SchemaLoaderSchemaLoader1,0
+class OpenAPIParser::SchemaLoaderOpenAPIParser::SchemaLoader1,0
+class OpenAPIParser::SchemaLoaderSchemaLoader13,0
+class OpenAPIParser::SchemaLoaderOpenAPIParser::SchemaLoader13,0
+  def initialize(target_object, core)initialize16,0
+  attr_reader :childrenchildren24,0
+  def load_dataload_data29,0
+    attr_reader :core, :target_objectcore36,0
+    attr_reader :core, :target_objecttarget_object36,0
+    def load_data_by_schema_loader(schema_loader)load_data_by_schema_loader39,0
+    def register_child(object)register_child45,0
+    def all_loaderall_loader51,0
+
+lib/openapi_parser/errors.rb,5558
+module OpenAPIParserOpenAPIParser1,0
+  class OpenAPIError < StandardErrorOpenAPIError2,0
+  class OpenAPIError < StandardErrorOpenAPIParser::OpenAPIError2,0
+    def initialize(reference)initialize3,0
+  class ValidateError < OpenAPIErrorValidateError8,0
+  class ValidateError < OpenAPIErrorOpenAPIParser::ValidateError8,0
+    def initialize(data, type, reference)initialize9,0
+    def messagemessage15,0
+      def build_error_result(value, schema)build_error_result23,0
+  class NotNullError < OpenAPIErrorNotNullError29,0
+  class NotNullError < OpenAPIErrorOpenAPIParser::NotNullError29,0
+    def messagemessage30,0
+  class NotExistRequiredKey < OpenAPIErrorNotExistRequiredKey35,0
+  class NotExistRequiredKey < OpenAPIErrorOpenAPIParser::NotExistRequiredKey35,0
+    def initialize(keys, reference)initialize36,0
+    def messagemessage41,0
+  class NotExistPropertyDefinition < OpenAPIErrorNotExistPropertyDefinition46,0
+  class NotExistPropertyDefinition < OpenAPIErrorOpenAPIParser::NotExistPropertyDefinition46,0
+    def initialize(keys, reference)initialize47,0
+    def messagemessage52,0
+  class NotExistDiscriminatorMappedSchema < OpenAPIErrorNotExistDiscriminatorMappedSchema57,0
+  class NotExistDiscriminatorMappedSchema < OpenAPIErrorOpenAPIParser::NotExistDiscriminatorMappedSchema57,0
+    def initialize(mapped_schema_reference, reference)initialize58,0
+    def messagemessage63,0
+  class NotExistDiscriminatorPropertyName < OpenAPIErrorNotExistDiscriminatorPropertyName68,0
+  class NotExistDiscriminatorPropertyName < OpenAPIErrorOpenAPIParser::NotExistDiscriminatorPropertyName68,0
+    def initialize(key, value, reference)initialize69,0
+    def messagemessage75,0
+  class NotOneOf < OpenAPIErrorNotOneOf80,0
+  class NotOneOf < OpenAPIErrorOpenAPIParser::NotOneOf80,0
+    def initialize(value, reference)initialize81,0
+    def messagemessage86,0
+  class NotAnyOf < OpenAPIErrorNotAnyOf91,0
+  class NotAnyOf < OpenAPIErrorOpenAPIParser::NotAnyOf91,0
+    def initialize(value, reference)initialize92,0
+    def messagemessage97,0
+  class NotEnumInclude < OpenAPIErrorNotEnumInclude102,0
+  class NotEnumInclude < OpenAPIErrorOpenAPIParser::NotEnumInclude102,0
+    def initialize(value, reference)initialize103,0
+    def messagemessage108,0
+  class LessThanMinimum < OpenAPIErrorLessThanMinimum113,0
+  class LessThanMinimum < OpenAPIErrorOpenAPIParser::LessThanMinimum113,0
+    def initialize(value, reference)initialize114,0
+    def messagemessage119,0
+  class LessThanExclusiveMinimum < OpenAPIErrorLessThanExclusiveMinimum124,0
+  class LessThanExclusiveMinimum < OpenAPIErrorOpenAPIParser::LessThanExclusiveMinimum124,0
+    def initialize(value, reference)initialize125,0
+    def messagemessage130,0
+  class MoreThanMaximum < OpenAPIErrorMoreThanMaximum135,0
+  class MoreThanMaximum < OpenAPIErrorOpenAPIParser::MoreThanMaximum135,0
+    def initialize(value, reference)initialize136,0
+    def messagemessage141,0
+  class MoreThanExclusiveMaximum < OpenAPIErrorMoreThanExclusiveMaximum146,0
+  class MoreThanExclusiveMaximum < OpenAPIErrorOpenAPIParser::MoreThanExclusiveMaximum146,0
+    def initialize(value, reference)initialize147,0
+    def messagemessage152,0
+  class InvalidPattern < OpenAPIErrorInvalidPattern157,0
+  class InvalidPattern < OpenAPIErrorOpenAPIParser::InvalidPattern157,0
+    def initialize(value, pattern, reference, example)initialize158,0
+    def messagemessage165,0
+  class InvalidEmailFormat < OpenAPIErrorInvalidEmailFormat170,0
+  class InvalidEmailFormat < OpenAPIErrorOpenAPIParser::InvalidEmailFormat170,0
+    def initialize(value, reference)initialize171,0
+    def messagemessage176,0
+  class InvalidUUIDFormat < OpenAPIErrorInvalidUUIDFormat181,0
+  class InvalidUUIDFormat < OpenAPIErrorOpenAPIParser::InvalidUUIDFormat181,0
+    def initialize(value, reference)initialize182,0
+    def messagemessage187,0
+  class InvalidDateFormat < OpenAPIErrorInvalidDateFormat192,0
+  class InvalidDateFormat < OpenAPIErrorOpenAPIParser::InvalidDateFormat192,0
+    def initialize(value, reference)initialize193,0
+    def messagemessage198,0
+  class NotExistStatusCodeDefinition < OpenAPIErrorNotExistStatusCodeDefinition203,0
+  class NotExistStatusCodeDefinition < OpenAPIErrorOpenAPIParser::NotExistStatusCodeDefinition203,0
+    def messagemessage204,0
+  class NotExistContentTypeDefinition < OpenAPIErrorNotExistContentTypeDefinition209,0
+  class NotExistContentTypeDefinition < OpenAPIErrorOpenAPIParser::NotExistContentTypeDefinition209,0
+    def messagemessage210,0
+  class MoreThanMaxLength < OpenAPIErrorMoreThanMaxLength215,0
+  class MoreThanMaxLength < OpenAPIErrorOpenAPIParser::MoreThanMaxLength215,0
+    def initialize(value, reference)initialize216,0
+    def messagemessage221,0
+  class LessThanMinLength < OpenAPIErrorLessThanMinLength226,0
+  class LessThanMinLength < OpenAPIErrorOpenAPIParser::LessThanMinLength226,0
+    def initialize(value, reference)initialize227,0
+    def messagemessage232,0
+  class MoreThanMaxItems < OpenAPIErrorMoreThanMaxItems237,0
+  class MoreThanMaxItems < OpenAPIErrorOpenAPIParser::MoreThanMaxItems237,0
+    def initialize(value, reference)initialize238,0
+    def messagemessage243,0
+  class LessThanMinItems < OpenAPIErrorLessThanMinItems248,0
+  class LessThanMinItems < OpenAPIErrorOpenAPIParser::LessThanMinItems248,0
+    def initialize(value, reference)initialize249,0
+    def messagemessage254,0
+
+lib/openapi_parser/reference_expander.rb,172
+class OpenAPIParser::ReferenceExpanderReferenceExpander1,0
+class OpenAPIParser::ReferenceExpanderOpenAPIParser::ReferenceExpander1,0
+    def expand(openapi)expand4,0
+
+lib/openapi_parser/schema_validators/object_validator.rb,420
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class ObjectValidator < BaseObjectValidator2,0
+  class ObjectValidator < BaseOpenAPIParser::SchemaValidator::ObjectValidator2,0
+    def coerce_and_validate(value, schema, parent_all_of: false, parent_discriminator_schemas: [], discriminator_property_name: nil)coerce_and_validate7,0
+
+lib/openapi_parser/schema_validators/string_validator.rb,916
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class StringValidator < BaseStringValidator2,0
+  class StringValidator < BaseOpenAPIParser::SchemaValidator::StringValidator2,0
+    def initialize(validator, coerce_value, datetime_coerce_class)initialize5,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate10,0
+      def coerce_date_time(value, schema)coerce_date_time42,0
+      def parse_date_time(value, schema)parse_date_time48,0
+      def pattern_validate(value, schema)pattern_validate59,0
+      def validate_max_min_length(value, schema)validate_max_min_length67,0
+      def validate_email_format(value, schema)validate_email_format74,0
+      def validate_uuid_format(value, schema)validate_uuid_format85,0
+      def validate_date_format(value, schema)validate_date_format93,0
+
+lib/openapi_parser/schema_validators/array_validator.rb,417
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class ArrayValidator < BaseArrayValidator2,0
+  class ArrayValidator < BaseOpenAPIParser::SchemaValidator::ArrayValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+    def validate_max_min_items(value, schema)validate_max_min_items25,0
+
+lib/openapi_parser/schema_validators/enumable.rb,288
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  module EnumableEnumable2,0
+  module EnumableOpenAPIParser::SchemaValidator::Enumable2,0
+    def check_enum_include(value, schema)check_enum_include6,0
+
+lib/openapi_parser/schema_validators/minimum_maximum.rb,366
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  module MinimumMaximumMinimumMaximum2,0
+  module MinimumMaximumOpenAPIParser::SchemaValidator::MinimumMaximum2,0
+    def check_minimum_maximum(value, schema)check_minimum_maximum6,0
+      def validate(value, schema)validate18,0
+
+lib/openapi_parser/schema_validators/boolean_validator.rb,713
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class BooleanValidator < BaseBooleanValidator2,0
+  class BooleanValidator < BaseOpenAPIParser::SchemaValidator::BooleanValidator2,0
+    TRUE_VALUES = ['true', '1'].freezeTRUE_VALUES5,0
+    TRUE_VALUES = ['true', '1'].freezeOpenAPIParser::SchemaValidator::BooleanValidator::TRUE_VALUES5,0
+    FALSE_VALUES = ['false', '0'].freezeFALSE_VALUES6,0
+    FALSE_VALUES = ['false', '0'].freezeOpenAPIParser::SchemaValidator::BooleanValidator::FALSE_VALUES6,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate8,0
+      def coerce(value)coerce21,0
+
+lib/openapi_parser/schema_validators/options.rb,945
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class OptionsOptions2,0
+  class OptionsOpenAPIParser::SchemaValidator::Options2,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headercoerce_value9,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headerdatetime_coerce_class9,0
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_headervalidate_header9,0
+    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true)initialize11,0
+  class ResponseValidateOptionsResponseValidateOptions19,0
+  class ResponseValidateOptionsOpenAPIParser::SchemaValidator::ResponseValidateOptions19,0
+    attr_reader :strict, :validate_headerstrict22,0
+    attr_reader :strict, :validate_headervalidate_header22,0
+    def initialize(strict: false, validate_header: true)initialize24,0
+
+lib/openapi_parser/schema_validators/unspecified_type_validator.rb,384
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class UnspecifiedTypeValidator < BaseUnspecifiedTypeValidator2,0
+  class UnspecifiedTypeValidator < BaseOpenAPIParser::SchemaValidator::UnspecifiedTypeValidator2,0
+    def coerce_and_validate(value, _schema, **_keyword_args)coerce_and_validate4,0
+
+lib/openapi_parser/schema_validators/nil_validator.rb,335
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class NilValidator < BaseNilValidator2,0
+  class NilValidator < BaseOpenAPIParser::SchemaValidator::NilValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/base.rb,527
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class BaseBase2,0
+  class BaseOpenAPIParser::SchemaValidator::Base2,0
+    def initialize(validatable, coerce_value)initialize4,0
+    attr_reader :validatablevalidatable9,0
+    def coerce_and_validate(_value, _schema, **_keyword_args)coerce_and_validate17,0
+    def validate_discriminator_schema(discriminator, value, parent_discriminator_schemas: [])validate_discriminator_schema21,0
+
+lib/openapi_parser/schema_validators/one_of_validator.rb,343
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class OneOfValidator < BaseOneOfValidator2,0
+  class OneOfValidator < BaseOpenAPIParser::SchemaValidator::OneOfValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/any_of_validator.rb,343
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class AnyOfValidator < BaseAnyOfValidator2,0
+  class AnyOfValidator < BaseOpenAPIParser::SchemaValidator::AnyOfValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate5,0
+
+lib/openapi_parser/schema_validators/float_validator.rb,467
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class FloatValidator < BaseFloatValidator2,0
+  class FloatValidator < BaseOpenAPIParser::SchemaValidator::FloatValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate9,0
+      def coercer_and_validate_numeric(value, schema)coercer_and_validate_numeric19,0
+      def coerce(value)coerce28,0
+
+lib/openapi_parser/schema_validators/integer_validator.rb,387
+class OpenAPIParser::SchemaValidatorSchemaValidator1,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator1,0
+  class IntegerValidator < BaseIntegerValidator2,0
+  class IntegerValidator < BaseOpenAPIParser::SchemaValidator::IntegerValidator2,0
+    def coerce_and_validate(value, schema, **_keyword_args)coerce_and_validate9,0
+      def coerce(value)coerce22,0
+
+lib/openapi_parser/schema_validators/all_of_validator.rb,342
+class OpenAPIParser::SchemaValidatorSchemaValidator2,0
+class OpenAPIParser::SchemaValidatorOpenAPIParser::SchemaValidator2,0
+  class AllOfValidator < BaseAllOfValidator3,0
+  class AllOfValidator < BaseOpenAPIParser::SchemaValidator::AllOfValidator3,0
+    def coerce_and_validate(value, schema, **keyword_args)coerce_and_validate7,0
+
+lib/openapi_parser/parameter_validator.rb,313
+class OpenAPIParser::ParameterValidatorParameterValidator1,0
+class OpenAPIParser::ParameterValidatorOpenAPIParser::ParameterValidator1,0
+    def validate_parameter(parameters_hash, params, object_reference, options, is_header = false)validate_parameter8,0
+    def convert_key(k, is_header)convert_key29,0
+
+lib/openapi_parser/path_item_finder.rb,1644
+class OpenAPIParser::PathItemFinderPathItemFinder1,0
+class OpenAPIParser::PathItemFinderOpenAPIParser::PathItemFinder1,0
+  def initialize(paths)initialize3,0
+  def operation_object(http_method, request_path)operation_object11,0
+  class ResultResult22,0
+  class ResultOpenAPIParser::PathItemFinder::Result22,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramspath_item_object23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramsoperation_object23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramsoriginal_path23,0
+    attr_reader :path_item_object, :operation_object, :original_path, :path_paramspath_params23,0
+    def initialize(path_item_object, operation_object, original_path, path_params)initialize33,0
+  def parse_path_parameters(schema_path, request_path)parse_path_parameters41,0
+    def path_parameters(schema_path)path_parameters66,0
+    def matches_directly?(request_path, http_method)matches_directly?77,0
+    def different_depth_or_method?(splitted_schema_path, splitted_request_path, path_item, http_method)different_depth_or_method?82,0
+    def path_template?(schema_path_item)path_template?88,0
+    def param_name(schema_path_item)param_name94,0
+    def extract_params(splitted_request_path, splitted_schema_path)extract_params103,0
+    def matching_paths_with_params(request_path, http_method)matching_paths_with_params124,0
+    def find_path_and_params(http_method, request_path)find_path_and_params141,0
+    def parse_request_path(http_method, request_path)parse_request_path151,0
+
+lib/openapi_parser/version.rb,144
+module OpenAPIParserOpenAPIParser1,0
+  VERSION = '1.0.0.beta1'.freezeVERSION2,0
+  VERSION = '1.0.0.beta1'.freezeOpenAPIParser::VERSION2,0
+
+lib/openapi_parser/request_operation.rb,1800
+class OpenAPIParser::RequestOperationRequestOperation3,0
+class OpenAPIParser::RequestOperationOpenAPIParser::RequestOperation3,0
+    def create(http_method, request_path, path_item_finder, config)create8,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemoperation_object28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itempath_params28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemconfig28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemhttp_method28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itemoriginal_path28,0
+  attr_reader :operation_object, :path_params, :config, :http_method, :original_path, :path_itempath_item28,0
+  def initialize(http_method, result, config)initialize33,0
+  def validate_path_params(options = nil)validate_path_params42,0
+  def validate_request_body(content_type, params, options = nil)validate_request_body50,0
+  def validate_response_body(response_body, response_validate_options = nil)validate_response_body57,0
+  def validate_request_parameter(params, headers, options = nil)validate_request_parameter66,0
+  class ValidatableResponseBodyValidatableResponseBody71,0
+  class ValidatableResponseBodyOpenAPIParser::RequestOperation::ValidatableResponseBody71,0
+    attr_reader :status_code, :response_data, :headersstatus_code72,0
+    attr_reader :status_code, :response_data, :headersresponse_data72,0
+    attr_reader :status_code, :response_data, :headersheaders72,0
+    def initialize(status_code, response_data, headers)initialize74,0
+    def content_typecontent_type80,0
+
+lib/openapi_parser/schemas/paths.rb,185
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Paths < BasePaths2,0
+  class Paths < BaseOpenAPIParser::Schemas::Paths2,0
+
+lib/openapi_parser/schemas/media_type.rb,269
+module OpenAPIParser::SchemasSchemas5,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas5,0
+  class MediaType < BaseMediaType6,0
+  class MediaType < BaseOpenAPIParser::Schemas::MediaType6,0
+    def validate_parameter(params, options)validate_parameter14,0
+
+lib/openapi_parser/schemas/operation.rb,380
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class Operation < BaseOperation7,0
+  class Operation < BaseOpenAPIParser::Schemas::Operation7,0
+    def validate_request_body(content_type, params, options)validate_request_body24,0
+    def validate_response(response_body, response_validate_options)validate_response30,0
+
+lib/openapi_parser/schemas/response.rb,398
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Response < BaseResponse4,0
+  class Response < BaseOpenAPIParser::Schemas::Response4,0
+    def validate(response_body, response_validate_options)validate19,0
+    def select_media_type(content_type)select_media_type36,0
+      def validate_header(response_headers)validate_header43,0
+
+lib/openapi_parser/schemas/discriminator.rb,217
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Discriminator < BaseDiscriminator2,0
+  class Discriminator < BaseOpenAPIParser::Schemas::Discriminator2,0
+
+lib/openapi_parser/schemas/path_item.rb,305
+module OpenAPIParser::SchemasSchemas4,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas4,0
+  class PathItem < BasePathItem5,0
+  class PathItem < BaseOpenAPIParser::Schemas::PathItem5,0
+    def operation(method)operation12,0
+    def set_path_item_to_operationset_path_item_to_operation18,0
+
+lib/openapi_parser/schemas/openapi.rb,456
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class OpenAPI < BaseOpenAPI7,0
+  class OpenAPI < BaseOpenAPIParser::Schemas::OpenAPI7,0
+    def initialize(raw_schema, config, uri: nil, schema_registry: {})initialize8,0
+    def request_operation(http_method, request_path)request_operation33,0
+    def load_another_schema(uri)load_another_schema39,0
+      def resolve_uri(uri)resolve_uri51,0
+
+lib/openapi_parser/schemas/responses.rb,422
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Responses < BaseResponses4,0
+  class Responses < BaseOpenAPIParser::Schemas::Responses4,0
+    def validate(response_body, response_validate_options)validate18,0
+      def find_response_object(status_code)find_response_object35,0
+      def status_code_to_wild_card(status_code)status_code_to_wild_card51,0
+
+lib/openapi_parser/schemas/header.rb,227
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Header < BaseHeader2,0
+  class Header < BaseOpenAPIParser::Schemas::Header2,0
+    def validate(value)validate14,0
+
+lib/openapi_parser/schemas/base.rb,618
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class BaseBase2,0
+  class BaseOpenAPIParser::Schemas::Base2,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootparent7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootraw_schema7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootobject_reference7,0
+    attr_reader :parent, :raw_schema, :object_reference, :rootroot7,0
+    def initialize(object_reference, parent, root, raw_schema)initialize10,0
+    def after_initafter_init21,0
+    def inspectinspect24,0
+
+lib/openapi_parser/schemas/schema.rb,247
+module OpenAPIParser::SchemasSchemas5,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas5,0
+  class Schema < BaseSchema6,0
+  class Schema < BaseOpenAPIParser::Schemas::Schema6,0
+    def additional_propertiesadditional_properties113,0
+
+lib/openapi_parser/schemas/reference.rb,201
+module OpenAPIParser::SchemasSchemas1,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas1,0
+  class Reference < BaseReference2,0
+  class Reference < BaseOpenAPIParser::Schemas::Reference2,0
+
+lib/openapi_parser/schemas/parameter.rb,263
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Parameter < BaseParameter4,0
+  class Parameter < BaseOpenAPIParser::Schemas::Parameter4,0
+    def validate_params(params, options)validate_params16,0
+
+lib/openapi_parser/schemas/classes.rb,1735
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class Base; endBase4,0
+  class Base; endOpenAPIParser::Schemas::Base4,0
+  class Discriminator < Base; endDiscriminator5,0
+  class Discriminator < Base; endOpenAPIParser::Schemas::Discriminator5,0
+  class OpenAPI < Base; endOpenAPI6,0
+  class OpenAPI < Base; endOpenAPIParser::Schemas::OpenAPI6,0
+  class Operation < Base; endOperation7,0
+  class Operation < Base; endOpenAPIParser::Schemas::Operation7,0
+  class Parameter < Base; endParameter8,0
+  class Parameter < Base; endOpenAPIParser::Schemas::Parameter8,0
+  class PathItem < Base; endPathItem9,0
+  class PathItem < Base; endOpenAPIParser::Schemas::PathItem9,0
+  class Paths < Base; endPaths10,0
+  class Paths < Base; endOpenAPIParser::Schemas::Paths10,0
+  class Reference < Base; endReference11,0
+  class Reference < Base; endOpenAPIParser::Schemas::Reference11,0
+  class RequestBody < Base; endRequestBody12,0
+  class RequestBody < Base; endOpenAPIParser::Schemas::RequestBody12,0
+  class Responses < Base; endResponses13,0
+  class Responses < Base; endOpenAPIParser::Schemas::Responses13,0
+  class Response < Base; endResponse14,0
+  class Response < Base; endOpenAPIParser::Schemas::Response14,0
+  class MediaType < Base; endMediaType15,0
+  class MediaType < Base; endOpenAPIParser::Schemas::MediaType15,0
+  class Schema < Base; endSchema16,0
+  class Schema < Base; endOpenAPIParser::Schemas::Schema16,0
+  class Components < Base; endComponents17,0
+  class Components < Base; endOpenAPIParser::Schemas::Components17,0
+  class Header < Base; endHeader18,0
+  class Header < Base; endOpenAPIParser::Schemas::Header18,0
+
+lib/openapi_parser/schemas/request_body.rb,360
+module OpenAPIParser::SchemasSchemas3,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas3,0
+  class RequestBody < BaseRequestBody4,0
+  class RequestBody < BaseOpenAPIParser::Schemas::RequestBody4,0
+    def validate_request_body(content_type, params, options)validate_request_body20,0
+    def select_media_type(content_type)select_media_type30,0
+
+lib/openapi_parser/schemas/components.rb,205
+module OpenAPIParser::SchemasSchemas6,0
+module OpenAPIParser::SchemasOpenAPIParser::Schemas6,0
+  class Components < BaseComponents7,0
+  class Components < BaseOpenAPIParser::Schemas::Components7,0

--- a/lib/openapi_parser/concerns/findable.rb
+++ b/lib/openapi_parser/concerns/findable.rb
@@ -46,8 +46,8 @@ module OpenAPIParser::Findable
   private
 
     def find_remote_object(reference)
-      reference_uri = URI(reference)
-      fragment = reference_uri.fragment
+      uri, fragment = reference.split("#")
+      reference_uri = URI(uri)
       reference_uri.fragment = nil
       root.load_another_schema(reference_uri)&.find_object("##{fragment}")
     end

--- a/lib/openapi_parser/concerns/findable.rb
+++ b/lib/openapi_parser/concerns/findable.rb
@@ -46,7 +46,7 @@ module OpenAPIParser::Findable
   private
 
     def find_remote_object(reference)
-      uri, fragment = reference.split("#")
+      uri, fragment = reference.split("#", 2)
       reference_uri = URI(uri)
       reference_uri.fragment = nil
       root.load_another_schema(reference_uri)&.find_object("##{fragment}")

--- a/spec/data/path-item-ref-relative.yaml
+++ b/spec/data/path-item-ref-relative.yaml
@@ -3,13 +3,7 @@ info:
   version: 1.0.0
   title: OpenAPI3 Test
 paths:
-  /sample/{sample_id}:
-    parameters:
-      - name: sample_id
-        in: path
-        required: true
-        schema:
-          type: string
+  /ref-sample/relative:
     post:
       description: override here
       requestBody:
@@ -23,9 +17,5 @@ paths:
               required:
                 - test
       responses:
-        '204':
+        "204":
           description: empty
-  /ref-sample:
-    $ref: '#/paths/~1sample~1%7Bsample_id%7D'
-  /ref-sample/relative:
-    $ref: 'path-item-ref-relative.yaml#/paths/~1ref-sample~1relative'

--- a/spec/data/path-item-ref-relative.yaml
+++ b/spec/data/path-item-ref-relative.yaml
@@ -19,19 +19,3 @@ paths:
       responses:
         "204":
           description: empty
-  /ref-sample/relative#included:
-    post:
-      description: override here
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                test:
-                  type: string
-              required:
-                - test
-      responses:
-        "204":
-          description: empty

--- a/spec/data/path-item-ref-relative.yaml
+++ b/spec/data/path-item-ref-relative.yaml
@@ -19,3 +19,19 @@ paths:
       responses:
         "204":
           description: empty
+  /ref-sample/relative#included:
+    post:
+      description: override here
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                test:
+                  type: string
+              required:
+                - test
+      responses:
+        "204":
+          description: empty

--- a/spec/data/path-item-ref.yaml
+++ b/spec/data/path-item-ref.yaml
@@ -29,5 +29,3 @@ paths:
     $ref: '#/paths/~1sample~1%7Bsample_id%7D'
   /ref-sample/relative:
     $ref: 'path-item-ref-relative.yaml#/paths/~1ref-sample~1relative'
-  /ref-sample/relative#included:
-    $ref: 'path-item-ref-relative.yaml#/paths/~1ref-sample~1relative#included'

--- a/spec/data/path-item-ref.yaml
+++ b/spec/data/path-item-ref.yaml
@@ -29,3 +29,5 @@ paths:
     $ref: '#/paths/~1sample~1%7Bsample_id%7D'
   /ref-sample/relative:
     $ref: 'path-item-ref-relative.yaml#/paths/~1ref-sample~1relative'
+  /ref-sample/relative#included:
+    $ref: 'path-item-ref-relative.yaml#/paths/~1ref-sample~1relative#included'

--- a/spec/openapi_parser/path_item_ref_spec.rb
+++ b/spec/openapi_parser/path_item_ref_spec.rb
@@ -1,7 +1,9 @@
 require_relative '../spec_helper'
 
 RSpec.describe 'path item $ref' do
-  let(:root) { OpenAPIParser.parse(path_item_ref_schema, {}) }
+  let(:root) { OpenAPIParser.parse_with_filepath(
+    path_item_ref_schema, path_item_ref_schema_path, {})
+  }
   let(:request_operation) { root.request_operation(:post, '/ref-sample') }
 
   it 'understands path item $ref' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,8 +60,12 @@ def yaml_with_unsupported_extension_petstore_schema_path
   './spec/data/petstore.yaml.unsupported_extension'
 end
 
+def path_item_ref_schema_path
+  './spec/data/path-item-ref.yaml'
+end
+
 def path_item_ref_schema
-  YAML.load_file('./spec/data/path-item-ref.yaml')
+  YAML.load_file(path_item_ref_schema_path)
 end
 
 def build_validate_test_schema(new_properties)


### PR DESCRIPTION
Path reference of other file cannot parse by json pointer escape (ex. '/' -> '~1' ).

We need to separate each path file for large open-api document.

example yaml file:

```yaml
# Root.yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: OpenAPI3 Sample
paths:
  /ref-sample/relative:
    $ref: 'Pets.yaml#/paths/~1pets~1owners'

# Pets.yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: OpenAPI3 Sample
paths:
  /pets/owners:
    ...
```

error message:

```shell
URI::InvalidURIError:
  bad URI(is not URI?): "Pets.yml#/paths/~1pets~1owners"
# /usr/local/bundle/gems/openapi_parser-0.14.1/lib/openapi_parser/concerns/findable.rb:49:in `find_remote_object'

```
