### PR TITLE
Use `nil` when nullable is true when choosing validator

### DIFF
--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -114,7 +114,7 @@ class OpenAPIParser::SchemaValidator
       when 'array'
         array_validator
       else
-        unspecified_type_validator
+        schema.nullable ? nil : unspecified_type_validator
       end
     end
 

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -258,6 +258,10 @@ paths:
                     mapping:
                       obj1: '#/components/schemas/one_of_object1'
                       obj2: '#/components/schemas/one_of_object2'
+                one_of_with_nullable:
+                  oneOf:
+                    - nullable: true
+                    - $ref: '#/components/schemas/one_of_object1'
                 object_1:
                   type: object
                   properties:

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -425,6 +425,26 @@ RSpec.describe OpenAPIParser::SchemaValidator do
 
         it { expect(subject).not_to eq nil }
       end
+
+      context 'nullable' do
+        subject { request_operation.validate_request_body(content_type, { 'one_of_with_nullable' => params }) }
+
+        let(:correct_params) do
+          {
+            'name' => 'name',
+            'integer_1' => 42,
+          }
+        end
+        let(:params) { correct_params }
+
+        it { expect(subject).not_to eq nil }
+
+        context 'null value' do
+          let(:params) { nil }
+
+          it { expect(subject).not_to eq nil }
+        end
+      end
     end
 
     it 'unknown param' do


### PR DESCRIPTION
It seems #109 brings a side-effect which fails a OneOf schema when it's nullable. Current logic makes a valid value falls into multiple matched case.