### PR TITLE
Add date-time format validation

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -206,6 +206,17 @@ module OpenAPIParser
     end
   end
 
+  class InvalidDateTimeFormat < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@reference} Value: #{@value.inspect} is not conformant with date-time format"
+    end
+  end
+
   class NotExistStatusCodeDefinition < OpenAPIError
     def message
       "#{@reference} status code definition does not exist"

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -16,11 +16,6 @@ class OpenAPIParser::SchemaValidator
       value, err = pattern_validate(value, schema)
       return [nil, err] if err
 
-      unless @datetime_coerce_class.nil?
-        value, err = coerce_date_time(value, schema)
-        return [nil, err] if err
-      end
-
       value, err = validate_max_min_length(value, schema)
       return [nil, err] if err
 
@@ -33,27 +28,13 @@ class OpenAPIParser::SchemaValidator
       value, err = validate_date_format(value, schema)
       return [nil, err] if err
 
+      value, err = validate_datetime_format(value, schema)
+      return [nil, err] if err
+
       [value, nil]
     end
 
     private
-
-      # @param [OpenAPIParser::Schemas::Schema] schema
-      def coerce_date_time(value, schema)
-        return parse_date_time(value, schema) if schema.format == 'date-time'
-
-        [value, nil]
-      end
-
-      def parse_date_time(value, schema)
-        begin
-          return @datetime_coerce_class.parse(value), nil
-        rescue ArgumentError => e
-          raise e unless e.message =~ /invalid date/
-        end
-
-        OpenAPIParser::ValidateError.build_error_result(value, schema)
-      end
 
       # @param [OpenAPIParser::Schemas::Schema] schema
       def pattern_validate(value, schema)
@@ -100,6 +81,24 @@ class OpenAPIParser::SchemaValidator
         end
 
         return [value, nil]
+      end
+
+      def validate_datetime_format(value, schema)
+        return [value, nil] unless schema.format == 'date-time'
+
+        begin
+          if @datetime_coerce_class.nil?
+            # validate only
+            Time.iso8601(value)
+            [value, nil]
+          else
+            # validate and coerce
+            [@datetime_coerce_class.iso8601(value), nil]
+          end
+        rescue ArgumentError
+          # when iso8601(value) failed
+          [nil, OpenAPIParser::InvalidDateTimeFormat.new(value, schema.object_reference)]
+        end
       end
   end
 end

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -89,14 +89,18 @@ class OpenAPIParser::SchemaValidator
         begin
           if @datetime_coerce_class.nil?
             # validate only
-            Time.iso8601(value)
+            DateTime.rfc3339(value)
             [value, nil]
           else
             # validate and coerce
-            [@datetime_coerce_class.iso8601(value), nil]
+            if @datetime_coerce_class == Time
+              [DateTime.rfc3339(value).to_time, nil]
+            else
+              [@datetime_coerce_class.rfc3339(value), nil]
+            end
           end
         rescue ArgumentError
-          # when iso8601(value) failed
+          # when rfc3339(value) failed
           [nil, OpenAPIParser::InvalidDateTimeFormat.new(value, schema.object_reference)]
         end
       end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         let(:datetime_coerce_class) { Time }
 
         it 'return Time' do
-          expect(subject).to eq({ 'datetime_str' => Time.iso8601('2022-01-01T12:59:00.000+09:00') })
+          expect(subject).to eq({ 'datetime_str' => DateTime.rfc3339('2022-01-01T12:59:00.000+09:00').to_time })
         end
       end
 
@@ -264,19 +264,30 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         let(:datetime_coerce_class) { DateTime }
 
         it 'return DateTime' do
-          expect(subject).to eq({ 'datetime_str' => DateTime.iso8601('2022-01-01T12:59:00.000+09:00') })
+          expect(subject).to eq({ 'datetime_str' => DateTime.rfc3339('2022-01-01T12:59:00.000+09:00') })
         end
       end
     end
 
     context 'invalid' do
-      context 'error pattern' do
+      context 'arbitrary string' do
         let(:params) { { 'datetime_str' => 'not_date' } }
 
         it do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidDateTimeFormat)
             expect(e.message).to end_with("Value: \"not_date\" is not conformant with date-time format")
+          end
+        end
+      end
+
+      context 'datetime without timezone' do
+        let(:params) { { 'datetime_str' => '2022-01-01T12:59:00.000' } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidDateTimeFormat)
+            expect(e.message).to end_with("Value: \"2022-01-01T12:59:00.000\" is not conformant with date-time format")
           end
         end
       end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -227,4 +227,59 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
       end
     end
   end
+
+  describe 'validate date-time format' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:replace_schema) do
+      {
+        datetime_str: {
+          type: 'string',
+          format: 'date-time',
+        },
+      }
+    end
+
+    context 'correct' do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new(coerce_value: true, datetime_coerce_class: datetime_coerce_class) }
+      let(:params) { { 'datetime_str' => '2022-01-01T12:59:00.000+09:00' } }
+
+      context 'when datetime_coerce_class is nil' do
+        let(:datetime_coerce_class) { nil }
+
+        it 'return String' do
+          expect(subject).to eq({ 'datetime_str' => '2022-01-01T12:59:00.000+09:00' })
+        end
+      end
+
+      context 'when datetime_coerce_class is Time' do
+        let(:datetime_coerce_class) { Time }
+
+        it 'return Time' do
+          expect(subject).to eq({ 'datetime_str' => Time.iso8601('2022-01-01T12:59:00.000+09:00') })
+        end
+      end
+
+      context 'when datetime_coerce_class is DateTime' do
+        let(:datetime_coerce_class) { DateTime }
+
+        it 'return DateTime' do
+          expect(subject).to eq({ 'datetime_str' => DateTime.iso8601('2022-01-01T12:59:00.000+09:00') })
+        end
+      end
+    end
+
+    context 'invalid' do
+      context 'error pattern' do
+        let(:params) { { 'datetime_str' => 'not_date' } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidDateTimeFormat)
+            expect(e.message).to end_with("Value: \"not_date\" is not conformant with date-time format")
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -764,7 +764,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
       context 'invalid datetime raise validation error' do
         let(:params) { { 'datetime_string' => 'honoka' } }
 
-        it { expect { subject }.to raise_error(OpenAPIParser::ValidateError) }
+        it { expect { subject }.to raise_error(OpenAPIParser::InvalidDateTimeFormat) }
       end
 
       context "don't change object type" do


### PR DESCRIPTION
Add date-time format validation.
This change does not change the behavior of the datetime_coerce_class option on success.
However, the exception class for failures has changed.

Refs.
- http://spec.openapis.org/oas/v3.0.3#data-types
- https://tools.ietf.org/html/rfc3339#section-5.6
- https://docs.ruby-lang.org/ja/latest/method/Time/s/iso8601.html