### PR TITLE
Fix nullable field does not work with allOf, anyOf and oneOf keyword

### DIFF
--- a/lib/openapi_parser/schema_validator/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validator/all_of_validator.rb
@@ -5,6 +5,10 @@ class OpenAPIParser::SchemaValidator
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema, **keyword_args)
+      if value.nil? && schema.nullable
+        return [value, nil]
+      end
+
       # if any schema return error, it's not valida all of value
       remaining_keys               = value.kind_of?(Hash) ? value.keys : []
       nested_additional_properties = false

--- a/lib/openapi_parser/schema_validator/any_of_validator.rb
+++ b/lib/openapi_parser/schema_validator/any_of_validator.rb
@@ -3,6 +3,9 @@ class OpenAPIParser::SchemaValidator
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema, **_keyword_args)
+      if value.nil? && schema.nullable
+        return [value, nil]
+      end
       if schema.discriminator
         return validate_discriminator_schema(schema.discriminator, value)
       end

--- a/lib/openapi_parser/schema_validator/one_of_validator.rb
+++ b/lib/openapi_parser/schema_validator/one_of_validator.rb
@@ -3,6 +3,9 @@ class OpenAPIParser::SchemaValidator
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema, **_keyword_args)
+      if value.nil? && schema.nullable
+        return [value, nil]
+      end
       if schema.discriminator
         return validate_discriminator_schema(schema.discriminator, value)
       end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -245,6 +245,10 @@ paths:
                         id:
                           type: integer
                           format: int64
+                all_of_with_nullable:
+                  nullable: true
+                  allOf:
+                    - type: integer
                 one_of_data:
                   oneOf:
                     - $ref: '#/components/schemas/one_of_object1'
@@ -258,6 +262,10 @@ paths:
                     mapping:
                       obj1: '#/components/schemas/one_of_object1'
                       obj2: '#/components/schemas/one_of_object2'
+                one_of_with_nullable:
+                  nullable: true
+                  oneOf:
+                    - type: integer
                 object_1:
                   type: object
                   properties:
@@ -314,6 +322,10 @@ paths:
                     anyOf:
                       - type: string
                       - type: boolean
+                any_of_with_nullable:
+                  nullable: true
+                  anyOf:
+                    - type: integer
                 unspecified_type: {}
                 enum_string:
                   type: string

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -209,6 +209,28 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         end
       end
 
+      context 'anyOf with nullable' do
+        subject { request_operation.validate_request_body(content_type, { 'any_of_with_nullable' => params }) }
+
+        context 'integer' do
+          let(:params) { 1 }
+
+          it { expect(subject).to eq({ 'any_of_with_nullable' => 1 }) }
+        end
+
+        context 'null' do
+          let(:params) { nil }
+
+          it { expect(subject).to eq({ 'any_of_with_nullable' => nil }) }
+        end
+
+        context 'invalid' do
+          let(:params) { 'foo' }
+
+          it { expect { subject }.to raise_error(OpenAPIParser::NotAnyOf) }
+        end
+      end
+
       context 'unspecified_type' do
         it do
           expect(request_operation.validate_request_body(content_type, { 'unspecified_type' => "foo" })).
@@ -369,6 +391,30 @@ RSpec.describe OpenAPIParser::SchemaValidator do
       end
     end
 
+    describe 'allOf with nullable' do
+      context 'with nullable' do
+        subject { request_operation.validate_request_body(content_type, { 'all_of_with_nullable' => params }) }
+
+        context 'integer' do
+          let(:params) { 1 }
+
+          it { expect(subject).to eq({ 'all_of_with_nullable' => 1 }) }
+        end
+
+        context 'null' do
+          let(:params) { nil }
+
+          it { expect(subject).to eq({ 'all_of_with_nullable' => nil }) }
+        end
+
+        context 'invalid' do
+          let(:params) { 'foo' }
+
+          it { expect { subject }.to raise_error(::OpenAPIParser::ValidateError) }
+        end
+      end
+    end
+
     describe 'one_of' do
       context 'normal' do
         subject { request_operation.validate_request_body(content_type, { 'one_of_data' => params }) }
@@ -429,6 +475,28 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         let(:params) { correct_params }
 
         it { expect(subject).not_to eq nil }
+      end
+
+      context 'with nullable' do
+        subject { request_operation.validate_request_body(content_type, { 'one_of_with_nullable' => params }) }
+
+        context 'integer' do
+          let(:params) { 1 }
+
+          it { expect(subject).to eq({ 'one_of_with_nullable' => 1 }) }
+        end
+
+        context 'null' do
+          let(:params) { nil }
+
+          it { expect(subject).to eq({ 'one_of_with_nullable' => nil }) }
+        end
+
+        context 'invalid' do
+          let(:params) { 'foo' }
+
+          it { expect { subject }.to raise_error(OpenAPIParser::NotOneOf) }
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes validation error when null value is passed on `allOf`, `anyOf` and `oneOf` schemas with `nullable: true`.

Note: Instead of #125, `nullable` is used in `oneOf` schema itself.