### PR TITLE
Added option to disable email format validation.

### DIFF
--- a/lib/openapi_parser/config.rb
+++ b/lib/openapi_parser/config.rb
@@ -37,11 +37,16 @@ class OpenAPIParser::Config
     @config.fetch(:validate_header, true)
   end
 
+  def validate_email_format
+    @config.fetch(:validate_email_format, true)
+  end
+
   # @return [OpenAPIParser::SchemaValidator::Options]
   def request_validator_options
     @request_validator_options ||= OpenAPIParser::SchemaValidator::Options.new(coerce_value: coerce_value,
                                                                                datetime_coerce_class: datetime_coerce_class,
-                                                                               validate_header: validate_header)
+                                                                               validate_header: validate_header,
+                                                                               validate_email_format: validate_email_format)
   end
 
   alias_method :request_body_options, :request_validator_options
@@ -49,7 +54,8 @@ class OpenAPIParser::Config
 
   # @return [OpenAPIParser::SchemaValidator::ResponseValidateOptions]
   def response_validate_options
-    @response_validate_options ||= OpenAPIParser::SchemaValidator::ResponseValidateOptions.
-                                     new(strict: strict_response_validation, validate_header: validate_header)
+    @response_validate_options ||= OpenAPIParser::SchemaValidator::ResponseValidateOptions.new(strict: strict_response_validation,
+                                                                                               validate_header: validate_header,
+                                                                                               validate_email_format: validate_email_format)
   end
 end

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -54,6 +54,7 @@ class OpenAPIParser::SchemaValidator
     @schema = schema
     @coerce_value = options.coerce_value
     @datetime_coerce_class = options.datetime_coerce_class
+    @validate_email_format = options.validate_email_format
   end
 
   # execute validate data
@@ -119,7 +120,7 @@ class OpenAPIParser::SchemaValidator
     end
 
     def string_validator
-      @string_validator ||= OpenAPIParser::SchemaValidator::StringValidator.new(self, @coerce_value, @datetime_coerce_class)
+      @string_validator ||= OpenAPIParser::SchemaValidator::StringValidator.new(self, @coerce_value, @datetime_coerce_class, @validate_email_format)
     end
 
     def integer_validator

--- a/lib/openapi_parser/schema_validators/options.rb
+++ b/lib/openapi_parser/schema_validators/options.rb
@@ -6,12 +6,15 @@ class OpenAPIParser::SchemaValidator
     #   @return [Object, nil] coerce datetime string by this Object class
     # @!attribute [r] validate_header
     #   @return [Boolean] validate header or not
-    attr_reader :coerce_value, :datetime_coerce_class, :validate_header
+    # @!attribute [r] validate_email_format
+    #   @return [Boolean] validate email format or not
+    attr_reader :coerce_value, :datetime_coerce_class, :validate_header, :validate_email_format
 
-    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true)
+    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true, validate_email_format: true)
       @coerce_value = coerce_value
       @datetime_coerce_class = datetime_coerce_class
       @validate_header = validate_header
+      @validate_email_format = validate_email_format
     end
   end
 
@@ -19,11 +22,12 @@ class OpenAPIParser::SchemaValidator
   class ResponseValidateOptions
     # @!attribute [r] strict
     #   @return [Boolean] validate by strict (when not exist definition, raise error)
-    attr_reader :strict, :validate_header
+    attr_reader :strict, :validate_header, :validate_email_format
 
-    def initialize(strict: false, validate_header: true)
+    def initialize(strict: false, validate_header: true, validate_email_format: true)
       @strict = strict
       @validate_header = validate_header
+      @validate_email_format = validate_email_format
     end
   end
 end

--- a/lib/openapi_parser/schema_validators/string_validator.rb
+++ b/lib/openapi_parser/schema_validators/string_validator.rb
@@ -2,9 +2,10 @@ class OpenAPIParser::SchemaValidator
   class StringValidator < Base
     include ::OpenAPIParser::SchemaValidator::Enumable
 
-    def initialize(validator, coerce_value, datetime_coerce_class)
+    def initialize(validator, coerce_value, datetime_coerce_class, validate_email_format)
       super(validator, coerce_value)
       @datetime_coerce_class = datetime_coerce_class
+      @validate_email_format = validate_email_format
     end
 
     def coerce_and_validate(value, schema, **_keyword_args)
@@ -53,7 +54,7 @@ class OpenAPIParser::SchemaValidator
       end
 
       def validate_email_format(value, schema)
-        return [value, nil] unless schema.format == 'email'
+        return [value, nil] unless @validate_email_format && schema.format == 'email'
 
         # match? method is good performance.
         # So when we drop ruby 2.3 support we use match? method because this method add ruby 2.4

--- a/sig/openapi_parser/config.rbs
+++ b/sig/openapi_parser/config.rbs
@@ -11,6 +11,7 @@ module OpenAPIParser
     def expand_reference: -> bool
     def strict_response_validation: -> bool
     def validate_header: -> bool
+    def validate_email_format: -> bool
     def request_validator_options: -> OpenAPIParser::SchemaValidator::Options
     def response_validate_options: -> OpenAPIParser::SchemaValidator::ResponseValidateOptions
   end

--- a/sig/openapi_parser/schema_validators/options.rbs
+++ b/sig/openapi_parser/schema_validators/options.rbs
@@ -5,13 +5,15 @@ module OpenAPIParser
       attr_reader coerce_value: bool | nil
       attr_reader datetime_coerce_class: singleton(Object) | nil
       attr_reader validate_header: bool
-      def initialize: (?coerce_value: bool | nil, ?datetime_coerce_class: singleton(Object) | nil, ?validate_header: bool) -> untyped
+      attr_reader validate_email_format: bool
+      def initialize: (?coerce_value: bool | nil, ?datetime_coerce_class: singleton(Object) | nil, ?validate_header: bool, ?validate_email_format: bool) -> untyped
     end
 
     class ResponseValidateOptions
       attr_reader strict: bool
       attr_reader validate_header: bool
-      def initialize: (?strict: bool, ?validate_header: bool) -> untyped
+      attr_reader validate_email_format: bool
+      def initialize: (?strict: bool, ?validate_header: bool, ?validate_email_format: bool) -> untyped
     end
   end
 end

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -160,6 +160,13 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         end
       end
     end
+
+    context "disabled" do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new validate_email_format: false }
+      let(:params) { { 'email_str' => "Hello (RFC2822 address) <hello@example.com>" } }
+
+      it { expect(subject).to eq({ 'email_str' => "Hello (RFC2822 address) <hello@example.com>" }) }
+    end
   end
 
   describe 'validate uuid format' do


### PR DESCRIPTION
Hello there,

we're currently facing the problem that we have to support RFC2822 addresses which are not covered by Ruby's URI email pattern.
Instead of removing the format from our API documentation we decided to go with this option to disable the format validation here. Another option would be to use the mail gem for example as its parser supports this standard.

What do you think?

Best
Florian @ M-Tribes