### PR TITLE
Fix TypeError when array is passed to UnspecifiedTypeValidator

### DIFF
--- a/lib/openapi_parser/schema_validators/unspecified_type_validator.rb
+++ b/lib/openapi_parser/schema_validators/unspecified_type_validator.rb
@@ -2,7 +2,7 @@ class OpenAPIParser::SchemaValidator
   class UnspecifiedTypeValidator < Base
     # @param [Object] value
     def coerce_and_validate(value, _schema, **_keyword_args)
-      value
+      [value, nil]
     end
   end
 end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -214,6 +214,11 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           expect(request_operation.validate_request_body(content_type, { 'unspecified_type' => "foo" })).
             to eq({ 'unspecified_type' => "foo" })
         end
+
+        it do
+          expect(request_operation.validate_request_body(content_type, { 'unspecified_type' => [1, 2] })).
+            to eq({ 'unspecified_type' => [1, 2] })
+        end
       end
     end
 


### PR DESCRIPTION
Need to wrap value with array otherwise return value of `#validate_schema`
is assigned to `err` if `value` is an array.