### PR TITLE
Support maxProperties and minProperties

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -160,6 +160,28 @@ module OpenAPIParser
     end
   end
 
+  class LessThanMinProperties < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@reference} #{@value.size} is less than minProperties value"
+    end
+  end
+
+  class MoreThanMaxProperties < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@reference} #{@value.size} is more than maxProperties value"
+    end
+  end
+
   class InvalidPattern < OpenAPIError
     def initialize(value, pattern, reference, example)
       super(reference)

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -1,6 +1,7 @@
 require_relative 'schema_validator/options'
 require_relative 'schema_validator/enumable'
 require_relative 'schema_validator/minimum_maximum'
+require_relative 'schema_validator/properties_number'
 require_relative 'schema_validator/base'
 require_relative 'schema_validator/string_validator'
 require_relative 'schema_validator/integer_validator'

--- a/lib/openapi_parser/schema_validator/object_validator.rb
+++ b/lib/openapi_parser/schema_validator/object_validator.rb
@@ -1,5 +1,7 @@
 class OpenAPIParser::SchemaValidator
   class ObjectValidator < Base
+    include ::OpenAPIParser::SchemaValidator::PropertiesNumber
+
     # @param [Hash] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     # @param [Boolean] parent_all_of true if component is nested under allOf
@@ -50,7 +52,7 @@ class OpenAPIParser::SchemaValidator
 
       value.merge!(coerced_values.to_h) if @coerce_value
 
-      [value, nil]
+      check_properties_number(value, schema)
     end
   end
 end

--- a/lib/openapi_parser/schema_validator/properties_number.rb
+++ b/lib/openapi_parser/schema_validator/properties_number.rb
@@ -1,0 +1,30 @@
+class OpenAPIParser::SchemaValidator
+  module PropertiesNumber
+    # check minProperties and manProperties value by schema
+    # @param [Object] value
+    # @param [OpenAPIParser::Schemas::Schema] schema
+    def check_properties_number(value, schema)
+      include_properties_num = schema.minProperties || schema.maxProperties
+      return [value, nil] unless include_properties_num
+
+      validate(value, schema)
+      [value, nil]
+    rescue OpenAPIParser::OpenAPIError => e
+      return [nil, e]
+    end
+
+    private
+
+      def validate(value, schema)
+        reference = schema.object_reference
+
+        if schema.minProperties && (value.size < schema.minProperties)
+          raise OpenAPIParser::LessThanMinProperties.new(value, reference)
+        end
+
+        if schema.maxProperties && (value.size > schema.maxProperties)
+          raise OpenAPIParser::MoreThanMaxProperties.new(value, reference)
+        end
+      end
+  end
+end


### PR DESCRIPTION
https://swagger.io/docs/specification/data-models/data-types/

> The minProperties and maxProperties keywords let you restrict the number of properties allowed in an object. This can be useful when using additionalProperties or free-form objects.