### PR TITLE
Deserialize Unexploded Query Parameters

### DIFF
--- a/lib/openapi_parser/schemas/parameter.rb
+++ b/lib/openapi_parser/schemas/parameter.rb
@@ -14,7 +14,27 @@ module OpenAPIParser::Schemas
     # @return [Object] coerced or original params
     # @param [OpenAPIParser::SchemaValidator::Options] options
     def validate_params(params, options)
-      ::OpenAPIParser::SchemaValidator.validate(params, schema, options)
+      ::OpenAPIParser::SchemaValidator.validate(deserialize(params), schema, options)
+    end
+
+    # Parameters can be serialized in several different ways
+    # See [documentation](https://swagger.io/docs/specification/serialization/) for details
+    # @return [Object] deserialized version of parameters
+    def deserialize(params)
+      # binding.pry
+      return params unless params.kind_of?(String)
+      if explode == false
+        delimiter = case style
+        when 'spaceDelimited'
+          ' '
+        when 'pipeDelimited'
+          '|'
+        else
+          ','
+        end
+        params = params.split(delimiter)
+      end
+      params
     end
   end
 end

--- a/spec/data/normal.yml
+++ b/spec/data/normal.yml
@@ -127,6 +127,34 @@ paths:
             type: array
             items:
               type: integer
+        - name: form_unexploded_array
+          in: query
+          description: array that looks like 'apple,banana,coconut'
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: space_unexploded_array
+          in: query
+          description: array that looks like '5 10 15'
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type:
+                integer
+        - name: pipe_unexploded_array
+          in: query
+          description: array that looks like 'first|second|last'
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
         - name: nested_array
           in: query
           description: nested_array

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -694,6 +694,57 @@ RSpec.describe OpenAPIParser::SchemaValidator do
         end
       end
 
+      context 'with style=form exploded=false array' do
+        let(:params) do
+          {
+            'form_unexploded_array' => 'apple,banana,coconut'
+          }
+        end
+
+        it do
+          expect(subject['form_unexploded_array'][0]).to eq 'apple'
+          expect(params['form_unexploded_array'][0]).to eq 'apple'
+          expect(subject['form_unexploded_array'][1]).to eq 'banana'
+          expect(params['form_unexploded_array'][1]).to eq 'banana'
+          expect(subject['form_unexploded_array'][2]).to eq 'coconut'
+          expect(params['form_unexploded_array'][2]).to eq 'coconut'
+        end
+      end
+
+      context 'with style=spaceDelimited exploded=false array' do
+        let(:params) do
+          {
+            'space_unexploded_array' => '5 10 15'
+          }
+        end
+
+        it do
+          expect(subject['space_unexploded_array'][0]).to eq 5
+          expect(params['space_unexploded_array'][0]).to eq 5
+          expect(subject['space_unexploded_array'][1]).to eq 10
+          expect(params['space_unexploded_array'][1]).to eq 10
+          expect(subject['space_unexploded_array'][2]).to eq 15
+          expect(params['space_unexploded_array'][2]).to eq 15
+        end
+      end
+
+      context 'with style=pipeDelimited exploded=false array' do
+        let(:params) do
+          {
+            'pipe_unexploded_array' => 'first|second|last'
+          }
+        end
+
+        it do
+          expect(subject['pipe_unexploded_array'][0]).to eq 'first'
+          expect(params['pipe_unexploded_array'][0]).to eq 'first'
+          expect(subject['pipe_unexploded_array'][1]).to eq 'second'
+          expect(params['pipe_unexploded_array'][1]).to eq 'second'
+          expect(subject['pipe_unexploded_array'][2]).to eq 'last'
+          expect(params['pipe_unexploded_array'][2]).to eq 'last'
+        end
+      end
+
       context 'nested_array' do
         let(:params) do
           { 'nested_array' => nested_array }


### PR DESCRIPTION
## Description
OpenAPI supports multiple methods of parameter deserialization. Documentation here: https://swagger.io/docs/specification/serialization/ In order to parse these comma-separated, pipe-delimited, and space-delimited arrays, we need to deserialize them according to the rules defined in the Parameter before checking them against the schema.

closes #122 

This is a rough draft of a way that we could handle this to open the conversation. Let me know if you want anything changed, extracted, or additional test cases in a different location.