### PR TITLE
Support for uniqueItems in array

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -272,4 +272,15 @@ module OpenAPIParser
       "#{@reference} #{@value.inspect} contains fewer than min items"
     end
   end
+
+  class NotUniqueItems < OpenAPIError
+    def initialize(value, reference)
+      super(reference)
+      @value = value
+    end
+
+    def message
+      "#{@reference} #{@value.inspect} contains duplicate items"
+    end
+  end
 end

--- a/lib/openapi_parser/schema_validator/array_validator.rb
+++ b/lib/openapi_parser/schema_validator/array_validator.rb
@@ -8,6 +8,9 @@ class OpenAPIParser::SchemaValidator
       value, err = validate_max_min_items(value, schema)
       return [nil, err] if err
 
+      value, err = validate_unique_items(value, schema)
+      return [nil, err] if err
+
       # array type have an schema in items property
       items_schema = schema.items
       coerced_values = value.map do |v|
@@ -25,6 +28,12 @@ class OpenAPIParser::SchemaValidator
     def validate_max_min_items(value, schema)
       return [nil, OpenAPIParser::MoreThanMaxItems.new(value, schema.object_reference)] if schema.maxItems && value.length > schema.maxItems
       return [nil, OpenAPIParser::LessThanMinItems.new(value, schema.object_reference)] if schema.minItems && value.length < schema.minItems
+
+      [value, nil]
+    end
+
+    def validate_unique_items(value, schema)
+      return [nil, OpenAPIParser::NotUniqueItems.new(value, schema.object_reference)] if schema.uniqueItems && value.length != value.uniq.length
 
       [value, nil]
     end

--- a/spec/openapi_parser/schema_validator/array_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/array_validator_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe OpenAPIParser::SchemaValidator::ArrayValidator do
           type: 'array',
           items: { 'type': 'integer' },
           maxItems: 2,
-          minItems: 1
+          minItems: 1,
+          uniqueItems: true
         },
       }
     end
@@ -50,6 +51,18 @@ RSpec.describe OpenAPIParser::SchemaValidator::ArrayValidator do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::LessThanMinItems)
             expect(e.message).to end_with("#{invalid_array} contains fewer than min items")
+          end
+        end
+      end
+
+      context 'unique items breached' do
+        let(:invalid_array) { [1, 1] }
+        let(:params) { { 'ids' => invalid_array } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::NotUniqueItems)
+            expect(e.message).to end_with("#{invalid_array} contains duplicate items")
           end
         end
       end


### PR DESCRIPTION
Hi @ota42y,
I have added validation of the uniqueness of items in array.
This enables us to raise errors in arrays like `[1, 1, 3]`.

```
type: array
items:
  type: integer
uniqueItems: true
```

https://swagger.io/docs/specification/data-models/data-types/