### PR TITLE
drop ruby 2.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 1.1.0 (2023-10-15)
+### Added
+* Support for uniqueItems in array #154
+* Fix nullable field does not work with allOf, anyOf and oneOf keyword #128
+
 ## 1.0.0 (2021-02-03)
 ### Added
 * Add date-time format validation #126

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task :steep do
-sh 'steep check'
+    sh 'steep check'
 end
 
 task :default => [:steep, :spec]

--- a/lib/openapi_parser/version.rb
+++ b/lib/openapi_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenAPIParser
-  VERSION = '1.0.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/openapi_parser.gemspec
+++ b/openapi_parser.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'parser for OpenAPI 3.0 or later'
   spec.homepage      = 'https://github.com/ota42y/openapi_parser'
   spec.license       = 'MIT'
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
error occured

```
Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use 
`gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid
 future breakage and silence this warning by running `gem update --system 3.2.3`
```