### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Unreleased
-
-## 1.1.0 (2023-10-15)
+## 2.0.0 (2023-10-15)
 ### Added
+
 * Support for uniqueItems in array #154
 * Fix nullable field does not work with allOf, anyOf and oneOf keyword #128
+
+### Other
+
+* Drop Ruby 2.6 Support #158
 
 ## 1.0.0 (2021-02-03)
 ### Added


### PR DESCRIPTION
- Fix wrong version number
- Add the changes that were missing "Drop 2.6 Ruby support"