### PR TITLE
Remove unused codes

### DIFF
--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -81,14 +81,11 @@ module OpenAPIParser
       end
 
       def parse_yaml(content)
-        # FIXME: when drop ruby 2.5, we should use permitted_classes
-        (Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.6.0")) ? 
-          Psych.safe_load(content, [Date, Time]) : 
-          Psych.safe_load(content, permitted_classes: [Date, Time])
+        Psych.safe_load(content, permitted_classes: [Date, Time])
       end
 
       def parse_json(content)
-        raise "json content is nil" unless content 
+        raise "json content is nil" unless content
         JSON.parse(content)
       end
 

--- a/lib/openapi_parser/schema_validator/string_validator.rb
+++ b/lib/openapi_parser/schema_validator/string_validator.rb
@@ -55,10 +55,7 @@ class OpenAPIParser::SchemaValidator
       def validate_email_format(value, schema)
         return [value, nil] unless schema.format == 'email'
 
-        # match? method is good performance.
-        # So when we drop ruby 2.3 support we use match? method because this method add ruby 2.4
-        #return [value, nil] if value.match?(URI::MailTo::EMAIL_REGEXP)
-        return [value, nil] if value.match(URI::MailTo::EMAIL_REGEXP)
+        return [value, nil] if value.match?(URI::MailTo::EMAIL_REGEXP)
 
         return [nil, OpenAPIParser::InvalidEmailFormat.new(value, schema.object_reference)]
       end

--- a/spec/openapi_parser/request_operation_spec.rb
+++ b/spec/openapi_parser/request_operation_spec.rb
@@ -110,11 +110,7 @@ RSpec.describe OpenAPIParser::RequestOperation do
       it do
         expect { subject }.to raise_error do |e|
           expect(e).to be_kind_of(OpenAPIParser::ValidateError)
-          if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.4.0')
-            expect(e.message).to end_with("expected string, but received Fixnum: 1")
-          else
-            expect(e.message).to end_with("expected string, but received Integer: 1")
-          end
+          expect(e.message).to end_with("expected string, but received Integer: 1")
         end
       end
     end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -571,12 +571,7 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           nested_array = params['nested_array']
           first_data = nested_array[0]
           expect(first_data['update_time'].class).to eq DateTime
-
-          if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.4.0')
-            expect(first_data['per_page'].class).to eq Fixnum # rubocop:disable Lint/UnifiedInteger
-          else
-            expect(first_data['per_page'].class).to eq Integer
-          end
+          expect(first_data['per_page'].class).to eq Integer
         end
       end
 
@@ -774,27 +769,15 @@ RSpec.describe OpenAPIParser::SchemaValidator do
           nested_array = params['nested_array']
           first_data = nested_array[0]
           expect(first_data['update_time'].class).to eq String
-          if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.4.0')
-            expect(first_data['per_page'].class).to eq Fixnum # rubocop:disable Lint/UnifiedInteger
-          else
-            expect(first_data['per_page'].class).to eq Integer
-          end
+          expect(first_data['per_page'].class).to eq Integer
 
           second_data = nested_array[1]
           expect(second_data['update_time'].class).to eq String
-          if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.4.0')
-            expect(first_data['per_page'].class).to eq Fixnum # rubocop:disable Lint/UnifiedInteger
-          else
-            expect(first_data['per_page'].class).to eq Integer
-          end
+          expect(first_data['per_page'].class).to eq Integer
           expect(second_data['threshold'].class).to eq Float
 
           third_data = nested_array[2]
-          if Gem::Version.create(RUBY_VERSION) <= Gem::Version.create('2.4.0')
-            expect(first_data['per_page'].class).to eq Fixnum # rubocop:disable Lint/UnifiedInteger
-          else
-            expect(first_data['per_page'].class).to eq Integer
-          end
+          expect(first_data['per_page'].class).to eq Integer
           expect(third_data['threshold'].class).to eq Float
 
           expect(first_data['nested_coercer_object']['update_time'].class).to eq String


### PR DESCRIPTION
Now that we support Ruby 2.7 and above, we can remove conditions with versions lower than that.