### PR TITLE
Suppress "method redefined" warning

### DIFF
--- a/lib/openapi_parser/schemas/schema.rb
+++ b/lib/openapi_parser/schemas/schema.rb
@@ -110,6 +110,7 @@ module OpenAPIParser::Schemas
     openapi_attr_object :additional_properties, Schema, reference: true, allow_data_type: true, schema_key: :additionalProperties
     # additional_properties have default value
     # we should add default value feature in openapi_attr_object method, but we need temporary fix so override attr_reader
+    remove_method :additional_properties
     def additional_properties
       @additional_properties.nil? ? true : @additional_properties
     end


### PR DESCRIPTION
This code emits the following warning to anyone who uses the gem, unless they suppress it with something like the warning gem, or suppress all warnings:

    3.2.4/lib/ruby/gems/3.2.0/gems/openapi_parser-2.1.0/lib/openapi_parser/schemas/schema.rb:113: warning: method redefined; discarding old additional_properties

This has been the case for about five years, although the comments make reference to this situation being transitory.  It would be better to use the gem without it emitting warnings in the meantime.