### PR TITLE
Show allowed enum values for enum schema validation

### DIFF
--- a/lib/openapi_parser/errors.rb
+++ b/lib/openapi_parser/errors.rb
@@ -106,14 +106,19 @@ module OpenAPIParser
   end
 
   class NotEnumInclude < OpenAPIError
-    def initialize(value, reference)
+    def initialize(value, reference, allowed_enum_values)
       super(reference)
       @value = value
+      @allowed_enum_values = allowed_enum_values
     end
 
     def message
-      "#{@value.inspect} isn't part of the enum in #{@reference}"
+      "#{@value.inspect} isn't part of the enum in #{@reference} " \
+      "(allowed values are: #{allowed_enum_values})"
     end
+
+    private
+    attr_reader :allowed_enum_values
   end
 
   class LessThanMinimum < OpenAPIError

--- a/lib/openapi_parser/schema_validator/enumable.rb
+++ b/lib/openapi_parser/schema_validator/enumable.rb
@@ -7,7 +7,7 @@ class OpenAPIParser::SchemaValidator
       return [value, nil] unless schema.enum
       return [value, nil] if schema.enum.include?(value)
 
-      [nil, OpenAPIParser::NotEnumInclude.new(value, schema.object_reference)]
+      [nil, OpenAPIParser::NotEnumInclude.new(value, schema.object_reference, schema.enum)]
     end
   end
 end

--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -286,6 +286,13 @@ RSpec.describe OpenAPIParser::SchemaValidator do
             expect(e.message.start_with?("\"\" isn't part of the enum")).to eq true
           end
         end
+
+        it "includes allowed values" do
+          expect { request_operation.validate_request_body(content_type, { 'enum_string' => 'x' }) }.to raise_error do |e|
+            expect(e.kind_of?(OpenAPIParser::NotEnumInclude)).to eq true
+            expect(e.message).to match(/isn't part of the enum.*\(allowed values are: \[\"a\", \"b\"\]\)/)
+          end
+        end
       end
 
       context 'enum integer' do


### PR DESCRIPTION
We would like to include the allowed enum values in the error message to provide richer feedback. 

I added this as a proof of concept - Would you consider to add something like this? 

Let me know what else needs to be adjusted in this PR so that it can be included