### PR TITLE
add base64 devdep for ruby-head, as steep needs but doesn't explicitly require it

### DIFF
--- a/openapi_parser.gemspec
+++ b/openapi_parser.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-parameterized'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency "steep"
-  # for steep 
+  # for steep + ruby-head
+  spec.add_development_dependency 'base64', '~> 0.2.0'
   # https://github.com/soutaro/steep/issues/466
   spec.add_development_dependency "activesupport", '~> 6.0'
 end


### PR DESCRIPTION
For example, see: https://github.com/ota42y/openapi_parser/actions/runs/11315396259