### PR TITLE
Make content_type case insensitive

### DIFF
--- a/lib/openapi_parser/request_operation.rb
+++ b/lib/openapi_parser/request_operation.rb
@@ -78,7 +78,8 @@ class OpenAPIParser::RequestOperation
     end
 
     def content_type
-      headers['Content-Type'].to_s.split(';').first.to_s
+      content_type_key = headers.keys.detect { |k| k.casecmp?('Content-Type') }
+      headers[content_type_key].to_s.split(';').first.to_s
     end
   end
 end

--- a/spec/openapi_parser/request_operation_spec.rb
+++ b/spec/openapi_parser/request_operation_spec.rb
@@ -216,3 +216,24 @@ RSpec.describe OpenAPIParser::RequestOperation do
     end
   end
 end
+
+RSpec.describe OpenAPIParser::RequestOperation::ValidatableResponseBody do
+  describe '#content_type' do
+    context 'when key is lowercase' do
+      let(:headers) { {"content-type" => "application/json"} }
+        it 'finds the key' do
+          expect(
+            OpenAPIParser::RequestOperation::ValidatableResponseBody.new(nil, nil, headers).content_type
+          ).to eq "application/json"
+      end
+    end
+    context 'when key is mixed case' do
+      let(:headers) { {"Content-Type" => "application/json"} }
+        it 'finds the key' do
+          expect(
+            OpenAPIParser::RequestOperation::ValidatableResponseBody.new(nil, nil, headers).content_type
+          ).to eq "application/json"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The content_type method looks up the content type header in a case sensitive manner; this causes a validation error [here](https://github.com/ota42y/openapi_parser/blob/b88556b38f54a5cf59b27399b9a29333c34b859d/lib/openapi_parser/schemas/response.rb#L22-L25) when the response headers aren't sent in exactly as `Content-Type` and strict validation is enabled. 
This pull request makes the content_type method case insensitive.