### PR TITLE
Fix parent_discriminator_schemas being set to nil

### DIFF
--- a/lib/openapi_parser/schema_validator/all_of_validator.rb
+++ b/lib/openapi_parser/schema_validator/all_of_validator.rb
@@ -18,7 +18,7 @@ class OpenAPIParser::SchemaValidator
           value,
           s,
           :parent_all_of => true,
-          parent_discriminator_schemas: keyword_args[:parent_discriminator_schemas]
+          parent_discriminator_schemas: keyword_args[:parent_discriminator_schemas] || []
         )
 
         if s.type == "object"


### PR DESCRIPTION
In some cases `parent_discriminator_schemas` can be set to nil in AllOfValidator::coerce_and_validate method
resulting in an exception in OpenAPIParser::SchemaValidator::ObjectValidator in line:

```
if schema.discriminator && !parent_discriminator_schemas.include?(schema)
```

fails at `include?` for a NilClass