### PR TITLE
Skip validation if the format is `binary`, even if the value is not an actual string.

### DIFF
--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -378,4 +378,24 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
       end
     end
   end
+
+  describe 'validate binary format' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:replace_schema) do
+      {
+        binary: {
+          type: 'string',
+          format: 'binary',
+        },
+      }
+    end
+
+    context 'correct' do
+      context 'arbitrary object except string' do
+        let(:params) { { 'binary' => ['b', 'i', 'n', 'a', 'r', 'y'] } }
+        it { expect(subject).to eq({ 'binary' => ['b', 'i', 'n', 'a', 'r', 'y'] }) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ref #148

The motivation of this patch comes from https://github.com/interagent/committee/issues/255.