### PR TITLE
Allow empty date/date-time to pass validation

### DIFF
--- a/lib/openapi_parser/config.rb
+++ b/lib/openapi_parser/config.rb
@@ -11,6 +11,10 @@ class OpenAPIParser::Config
     @config = config
   end
 
+  def allow_empty_date_and_datetime
+    @config.fetch(:allow_empty_date_and_datetime, false)
+  end
+
   def datetime_coerce_class
     @config[:datetime_coerce_class]
   end
@@ -39,7 +43,8 @@ class OpenAPIParser::Config
 
   # @return [OpenAPIParser::SchemaValidator::Options]
   def request_validator_options
-    @request_validator_options ||= OpenAPIParser::SchemaValidator::Options.new(coerce_value: coerce_value,
+    @request_validator_options ||= OpenAPIParser::SchemaValidator::Options.new(allow_empty_date_and_datetime: allow_empty_date_and_datetime,
+                                                                               coerce_value: coerce_value,
                                                                                datetime_coerce_class: datetime_coerce_class,
                                                                                validate_header: validate_header)
   end

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -53,6 +53,7 @@ class OpenAPIParser::SchemaValidator
   def initialize(value, schema, options)
     @value = value
     @schema = schema
+    @allow_empty_date_and_datetime = options.allow_empty_date_and_datetime
     @coerce_value = options.coerce_value
     @datetime_coerce_class = options.datetime_coerce_class
   end
@@ -120,7 +121,7 @@ class OpenAPIParser::SchemaValidator
     end
 
     def string_validator
-      @string_validator ||= OpenAPIParser::SchemaValidator::StringValidator.new(self, @coerce_value, @datetime_coerce_class)
+      @string_validator ||= OpenAPIParser::SchemaValidator::StringValidator.new(self, @allow_empty_date_and_datetime, @coerce_value, @datetime_coerce_class)
     end
 
     def integer_validator

--- a/lib/openapi_parser/schema_validator/options.rb
+++ b/lib/openapi_parser/schema_validator/options.rb
@@ -1,14 +1,17 @@
 class OpenAPIParser::SchemaValidator
   class Options
+    # @!attribute [r] allow_empty_date_and_datetime
+    #   @return [Boolean] allow empty date and datetime values option on/off
     # @!attribute [r] coerce_value
     #   @return [Boolean] coerce value option on/off
     # @!attribute [r] datetime_coerce_class
     #   @return [Object, nil] coerce datetime string by this Object class
     # @!attribute [r] validate_header
     #   @return [Boolean] validate header or not
-    attr_reader :coerce_value, :datetime_coerce_class, :validate_header
+    attr_reader :allow_empty_date_and_datetime, :coerce_value, :datetime_coerce_class, :validate_header
 
-    def initialize(coerce_value: nil, datetime_coerce_class: nil, validate_header: true)
+    def initialize(allow_empty_date_and_datetime: false, coerce_value: nil, datetime_coerce_class: nil, validate_header: true)
+      @allow_empty_date_and_datetime = allow_empty_date_and_datetime
       @coerce_value = coerce_value
       @datetime_coerce_class = datetime_coerce_class
       @validate_header = validate_header

--- a/lib/openapi_parser/schema_validator/string_validator.rb
+++ b/lib/openapi_parser/schema_validator/string_validator.rb
@@ -2,8 +2,9 @@ class OpenAPIParser::SchemaValidator
   class StringValidator < Base
     include ::OpenAPIParser::SchemaValidator::Enumable
 
-    def initialize(validator, coerce_value, datetime_coerce_class)
+    def initialize(validator, allow_empty_date_and_datetime, coerce_value, datetime_coerce_class)
       super(validator, coerce_value)
+      @allow_empty_date_and_datetime = allow_empty_date_and_datetime
       @datetime_coerce_class = datetime_coerce_class
     end
 
@@ -80,6 +81,10 @@ class OpenAPIParser::SchemaValidator
       end
 
       def validate_date_format(value, schema)
+        if @allow_empty_date_and_datetime && value.to_s.empty?
+          return [value, nil] if schema.format == 'date'
+        end
+
         return [value, nil] unless schema.format == 'date'
 
         return [nil, OpenAPIParser::InvalidDateFormat.new(value, schema.object_reference)] unless value =~ /^\d{4}-\d{2}-\d{2}$/
@@ -98,6 +103,10 @@ class OpenAPIParser::SchemaValidator
       end
 
       def validate_datetime_format(value, schema)
+        if @allow_empty_date_and_datetime && value.to_s.empty?
+          return [value, nil] if schema.format == 'date-time'
+        end
+
         return [value, nil] unless schema.format == 'date-time'
 
         begin

--- a/sig/openapi_parser/config.rbs
+++ b/sig/openapi_parser/config.rbs
@@ -8,6 +8,7 @@ module OpenAPIParser
     alias path_params_options request_validator_options
 
     def initialize: (untyped config) -> untyped
+    def allow_empty_date_and_datetime: -> bool
     def datetime_coerce_class: -> (singleton(Object) | nil)
     def coerce_value: -> bool
     def expand_reference: -> bool

--- a/sig/openapi_parser/config.rbs
+++ b/sig/openapi_parser/config.rbs
@@ -12,6 +12,7 @@ module OpenAPIParser
     def coerce_value: -> bool
     def expand_reference: -> bool
     def strict_response_validation: -> bool
+    def strict_reference_validation: -> bool
     def validate_header: -> bool
     def request_validator_options: -> OpenAPIParser::SchemaValidator::Options
     def response_validate_options: -> OpenAPIParser::SchemaValidator::ResponseValidateOptions

--- a/sig/openapi_parser/schema_validators/options.rbs
+++ b/sig/openapi_parser/schema_validators/options.rbs
@@ -2,10 +2,11 @@
 module OpenAPIParser
   class SchemaValidator
     class Options
+      attr_reader allow_empty_date_and_datetime: bool | nil
       attr_reader coerce_value: bool | nil
       attr_reader datetime_coerce_class: singleton(Object) | nil
       attr_reader validate_header: bool
-      def initialize: (?coerce_value: bool | nil, ?datetime_coerce_class: singleton(Object) | nil, ?validate_header: bool) -> untyped
+      def initialize: (?allow_empty_date_and_datetime: bool | nil, ?coerce_value: bool | nil, ?datetime_coerce_class: singleton(Object) | nil, ?validate_header: bool) -> untyped
     end
 
     class ResponseValidateOptions

--- a/spec/openapi_parser/schema_validator/string_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/string_validator_spec.rb
@@ -311,6 +311,30 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
         end
       end
     end
+
+    context 'when allow_empty_date_and_datetime is true' do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new(allow_empty_date_and_datetime: true) }
+
+      context 'empty string' do
+        let(:params) { { 'date_str' => '' } }
+        it { expect(subject).to eq({ 'date_str' => '' }) }
+      end
+    end
+
+    context 'when allow_empty_date_and_datetime is false' do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new(allow_empty_date_and_datetime: false) }
+
+      context 'empty string' do
+        let(:params) { { 'date_str' => '' } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidDateFormat)
+            expect(e.message).to end_with("Value: \"\" is not conformant with date format")
+          end
+        end
+      end
+    end
   end
 
   describe 'validate date-time format' do
@@ -373,6 +397,30 @@ RSpec.describe OpenAPIParser::SchemaValidator::StringValidator do
           expect { subject }.to raise_error do |e|
             expect(e).to be_kind_of(OpenAPIParser::InvalidDateTimeFormat)
             expect(e.message).to end_with("Value: \"2022-01-01T12:59:00.000\" is not conformant with date-time format")
+          end
+        end
+      end
+    end
+
+    context 'when allow_empty_date_and_datetime is true' do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new(allow_empty_date_and_datetime: true) }
+
+      context 'empty string' do
+        let(:params) { { 'datetime_str' => '' } }
+        it { expect(subject).to eq({ 'datetime_str' => '' }) }
+      end
+    end
+
+    context 'when allow_empty_date_and_datetime is false' do
+      let(:options) { ::OpenAPIParser::SchemaValidator::Options.new(allow_empty_date_and_datetime: false) }
+
+      context 'empty string' do
+        let(:params) { { 'datetime_str' => '' } }
+
+        it do
+          expect { subject }.to raise_error do |e|
+            expect(e).to be_kind_of(OpenAPIParser::InvalidDateTimeFormat)
+            expect(e.message).to end_with("Value: \"\" is not conformant with date-time format")
           end
         end
       end


### PR DESCRIPTION
This is the last patch from our recent update from Committee 4.4 to 5.

It seems empty string is considered valid for date/date-time from the spec, but I feel it's kind of grey area.

This change could also be backwards incompatible, so I'm open to suggestions on how to add an option or something. It wasn't obvious to me how we can pass options from Committee (we're mainly using for `assert_schema_conform` in our tests).

Here is the investigation from my colleague (@ydah) which I think adds a bit more context:

---

This is the most common testing pattern that this update has caused to fail.

The following changes to openapi_parser add date and date-time validation:
* https://github.com/ota42y/openapi_parser/pull/102
* https://github.com/ota42y/openapi_parser/pull/126

In the above fix, the empty string is InvalidResponse.
However, the OpenAPI specification written by swagger also seems to allow empty strings.

> Note that an empty string “” is a valid string unless minLength or pattern is specified.
> https://swagger.io/docs/specification/data-models/data-types/

However, it is not mentioned in https://spec.openapis.org/oas/v3.0.3#data-types. It also seems undefined.
After checking the specification in the [OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification), [the answer is that it depends on the tool.](https://github.com/OAI/OpenAPI-Specification/discussions/3324) So in this case you should follow the committee/openapi_parser.

>Looking at the RFC definition they reference: [full-date = date-fullyear "-" date-month "-" date-mday](https://www.rfc-editor.org/rfc/rfc3339.html#page-8)
So the definition of a "full-date" would not allow an empty string. So according to the "date" format an empty string would be invalid.
However it is explicitly stated that [Tools that do not recognize a specific format MAY default back to the type alone, as if the format is not specified.](https://spec.openapis.org/oas/v3.0.3#data-types).
So I think the answer is: "it depends on the tool you use" as it is the tool that decides whether format: date means anything.

So we have to choose one or the other:

#### 1. Change the swagger definition

Remove the definition of `format` from swagger where `type` specifies `string` and `format` specifies `date` or `format` specifies `date-time` and sends an empty string.

```diff
originated_at:
    type: string
-    format: date-time
    example: 2020-06-19T14:46:50.000+09:00
    nullable: true
```

This advantage can be changed to the format as expected by the committee. However, the disadvantage is that it is not possible to check the format where an empty string or date/date-time is expected.

---

Another idea I had was allowing `nullable` in this case to treat empty strings appropriately, just throwing that out there.