### PR TITLE
Support validator options on ResponseValidateOptions

### DIFF
--- a/lib/openapi_parser/schema_validator/options.rb
+++ b/lib/openapi_parser/schema_validator/options.rb
@@ -22,9 +22,10 @@ class OpenAPIParser::SchemaValidator
   class ResponseValidateOptions
     # @!attribute [r] strict
     #   @return [Boolean] validate by strict (when not exist definition, raise error)
-    attr_reader :strict, :validate_header
+    attr_reader :strict, :validate_header, :validator_options
 
-    def initialize(strict: false, validate_header: true)
+    def initialize(strict: false, validate_header: true, **validator_options)
+      @validator_options = validator_options
       @strict = strict
       @validate_header = validate_header
     end

--- a/lib/openapi_parser/schemas/response.rb
+++ b/lib/openapi_parser/schemas/response.rb
@@ -28,7 +28,7 @@ module OpenAPIParser::Schemas
         return true
       end
 
-      options = ::OpenAPIParser::SchemaValidator::Options.new # response validator not support any options
+      options = ::OpenAPIParser::SchemaValidator::Options.new(**response_validate_options.validator_options)
       media_type.validate_parameter(response_body.response_data, options)
     end
 


### PR DESCRIPTION
We need to be able to pass options to the validator when parsing responses too.