### PR TITLE
Support components.pathItems (OpenAPI 3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* support `components.pathItems` so `$ref`s into it resolve, unblocking OpenAPI 3.1 documents that use reusable path items
 
 ## 2.3.1 (2025-11-14)
 * add optional date coercion with behavior matching existing datetime coercion

--- a/lib/openapi_parser/schemas/components.rb
+++ b/lib/openapi_parser/schemas/components.rb
@@ -24,5 +24,9 @@ module OpenAPIParser::Schemas
     # @!attribute [r] headers
     #   @return [Hash{String => Header}, nil] header objects
     openapi_attr_hash_object :headers, Header, reference: true
+
+    # @!attribute [r] path_items
+    #   @return [Hash{String => PathItem}, nil] path item objects (OpenAPI 3.1+)
+    openapi_attr_hash_object :path_items, PathItem, reference: true, schema_key: :pathItems
   end
 end

--- a/spec/data/openapi_3_1/components_path_items.yaml
+++ b/spec/data/openapi_3_1/components_path_items.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Components.pathItems fixture
+  version: '1.0'
+paths:
+  /books:
+    $ref: '#/components/pathItems/LiteralPathItem'
+components:
+  pathItems:
+    LiteralPathItem:
+      get:
+        summary: Get something
+        responses:
+          '200':
+            description: OK
+    ReferencedPathItem:
+      $ref: '#/components/pathItems/LiteralPathItem'

--- a/spec/openapi_parser/concerns/expandable_spec.rb
+++ b/spec/openapi_parser/concerns/expandable_spec.rb
@@ -45,7 +45,14 @@ RSpec.describe OpenAPIParser::Expandable do
     end
 
     context 'a path that $refs into components.pathItems (OpenAPI 3.1)' do
-      it 'resolves the path item instead of raising MissingReferenceError'
+      it 'resolves the path item instead of raising MissingReferenceError' do
+        root = OpenAPIParser.parse(
+          load_yaml_file('./spec/data/openapi_3_1/components_path_items.yaml'),
+          strict_reference_validation: true,
+        )
+        expect(root.paths.path['/books'].class).to eq OpenAPIParser::Schemas::PathItem
+        expect(root.request_operation(:get, '/books').class).to eq OpenAPIParser::RequestOperation
+      end
     end
   end
 end

--- a/spec/openapi_parser/concerns/expandable_spec.rb
+++ b/spec/openapi_parser/concerns/expandable_spec.rb
@@ -43,5 +43,9 @@ RSpec.describe OpenAPIParser::Expandable do
         expect(subject.find_object(invalid_reference)).to be_nil
       end
     end
+
+    context 'a path that $refs into components.pathItems (OpenAPI 3.1)' do
+      it 'resolves the path item instead of raising MissingReferenceError'
+    end
   end
 end

--- a/spec/openapi_parser/schemas/components_spec.rb
+++ b/spec/openapi_parser/schemas/components_spec.rb
@@ -30,15 +30,23 @@ RSpec.describe OpenAPIParser::Schemas::Components do
     subject { root.find_object('#/components') }
 
     context 'with a literal Path Item Object entry' do
-      it 'is parsed as a PathItem'
+      it 'is parsed as a PathItem' do
+        expect(subject.path_items['LiteralPathItem'].class).to eq OpenAPIParser::Schemas::PathItem
+      end
     end
 
     context 'with a $ref entry pointing to another Path Item' do
-      it 'resolves to the referenced Path Item'
+      it 'resolves to the referenced Path Item' do
+        expect(subject.path_items['ReferencedPathItem'].class).to eq OpenAPIParser::Schemas::PathItem
+      end
     end
 
     context 'referenced from a path via $ref' do
-      it 'is expanded into the path'
+      it 'is expanded into the path' do
+        path_item = root.paths.path['/books']
+        expect(path_item.class).to eq OpenAPIParser::Schemas::PathItem
+        expect(path_item.get.summary).to eq 'Get something'
+      end
     end
   end
 end

--- a/spec/openapi_parser/schemas/components_spec.rb
+++ b/spec/openapi_parser/schemas/components_spec.rb
@@ -24,4 +24,21 @@ RSpec.describe OpenAPIParser::Schemas::Components do
       expect(subject.headers['X-Rate-Limit-Limit'].class).to eq OpenAPIParser::Schemas::Header
     end
   end
+
+  describe 'pathItems (OpenAPI 3.1)' do
+    let(:root) { OpenAPIParser.parse(load_yaml_file('./spec/data/openapi_3_1/components_path_items.yaml'), {}) }
+    subject { root.find_object('#/components') }
+
+    context 'with a literal Path Item Object entry' do
+      it 'is parsed as a PathItem'
+    end
+
+    context 'with a $ref entry pointing to another Path Item' do
+      it 'resolves to the referenced Path Item'
+    end
+
+    context 'referenced from a path via $ref' do
+      it 'is expanded into the path'
+    end
+  end
 end


### PR DESCRIPTION
First step toward OpenAPI 3.1 support (#152).

OpenAPI 3.1 adds `components.pathItems`, a map of reusable Path Item Objects that other path items can reference via `$ref`.
This PR adds a `path_items` attribute on `Components`, parsed as `Map[string, PathItem | Reference]` per the spec.

The attribute is reference-enabled, so the existing reference expander resolves `$ref`s into (and within) `components.pathItems` automatically.
A path that `$ref`s into `components.pathItems` previously failed with `MissingReferenceError` and now resolves:

```yaml
paths:
  /books:
    $ref: '#/components/pathItems/books_collection'
components:
  pathItems:
    books_collection:
      get:
        responses:
          '200':
            description: OK
```

Scope note: this is intentionally permissive.
`components.pathItems` is accepted even in 3.0 documents, where the spec disallows it.
Version-aware reporting (warn/raise on a version mismatch) comes later via the `SpecValidator` / `strict_specification_version` work discussed in #152.
