### PR TITLE
Add SpecValidator: detect version mismatches (exclusiveMinimum / exclusiveMaximum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 * support `components.pathItems` so `$ref`s into it resolve, unblocking OpenAPI 3.1 documents that use reusable path items
-* add `SpecValidator` with `strict_specification_version` config (`:silent` / `:warn` / `:raise`) to detect version mismatches between declared OpenAPI version and actual field usage; ships with `ExclusiveMinimum` rule detecting 3.0 Boolean vs 3.1 numeric form
-* support 3.1-style numeric `exclusiveMinimum` in value validation (standalone bound, not a Boolean modifier on `minimum`)
+* add `SpecValidator` with `strict_specification_version` config (`:silent` / `:warn` / `:raise`) to detect version mismatches between declared OpenAPI version and actual field usage
+  * `ExclusiveMinimum` / `ExclusiveMaximum`: detect 3.0 Boolean vs 3.1 numeric form mismatch
+* support 3.1-style numeric `exclusiveMinimum` / `exclusiveMaximum` in value validation (standalone bound, not a Boolean modifier on `minimum` / `maximum`)
 
 ## 2.3.1 (2025-11-14)
 * add optional date coercion with behavior matching existing datetime coercion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 * support `components.pathItems` so `$ref`s into it resolve, unblocking OpenAPI 3.1 documents that use reusable path items
+* add `SpecValidator` with `strict_specification_version` config (`:silent` / `:warn` / `:raise`) to detect version mismatches between declared OpenAPI version and actual field usage; ships with `ExclusiveMinimum` rule detecting 3.0 Boolean vs 3.1 numeric form
+* support 3.1-style numeric `exclusiveMinimum` in value validation (standalone bound, not a Boolean modifier on `minimum`)
 
 ## 2.3.1 (2025-11-14)
 * add optional date coercion with behavior matching existing datetime coercion

--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -100,6 +100,8 @@ module OpenAPIParser
           path_item.set_path_item_to_operation
         end
 
+        OpenAPIParser::SpecValidator.run!(root, policy: config.strict_specification_version)
+
         root
       end
   end

--- a/lib/openapi_parser.rb
+++ b/lib/openapi_parser.rb
@@ -15,6 +15,7 @@ require 'openapi_parser/request_operation'
 require 'openapi_parser/schema_validator'
 require 'openapi_parser/parameter_validator'
 require 'openapi_parser/reference_expander'
+require 'openapi_parser/spec_validator'
 
 module OpenAPIParser
   class << self

--- a/lib/openapi_parser/config.rb
+++ b/lib/openapi_parser/config.rb
@@ -41,6 +41,11 @@ class OpenAPIParser::Config
     @config.fetch(:strict_reference_validation, false)
   end
 
+  # @return [Symbol] :silent / :warn / :raise
+  def strict_specification_version
+    @config.fetch(:strict_specification_version, :silent)
+  end
+
   def validate_header
     @config.fetch(:validate_header, true)
   end

--- a/lib/openapi_parser/config.rb
+++ b/lib/openapi_parser/config.rb
@@ -41,9 +41,16 @@ class OpenAPIParser::Config
     @config.fetch(:strict_reference_validation, false)
   end
 
+  KNOWN_STRICT_SPECIFICATION_VERSION_VALUES = %i[silent warn raise].freeze
+
   # @return [Symbol] :silent / :warn / :raise
   def strict_specification_version
-    @config.fetch(:strict_specification_version, :silent)
+    value = @config.fetch(:strict_specification_version, :silent)
+    unless KNOWN_STRICT_SPECIFICATION_VERSION_VALUES.include?(value)
+      warn("[OpenAPIParser] unknown strict_specification_version: #{value.inspect}, falling back to :silent")
+      return :silent
+    end
+    value
   end
 
   def validate_header

--- a/lib/openapi_parser/schema_validator/minimum_maximum.rb
+++ b/lib/openapi_parser/schema_validator/minimum_maximum.rb
@@ -6,7 +6,8 @@ class OpenAPIParser::SchemaValidator
     def check_minimum_maximum(value, schema)
       has_min_or_max = schema.minimum || schema.maximum
       has_numeric_exclusive_min = schema.exclusiveMinimum.is_a?(Numeric)
-      return [value, nil] unless has_min_or_max || has_numeric_exclusive_min
+      has_numeric_exclusive_max = schema.exclusiveMaximum.is_a?(Numeric)
+      return [value, nil] unless has_min_or_max || has_numeric_exclusive_min || has_numeric_exclusive_max
 
       validate(value, schema)
       [value, nil]
@@ -33,8 +34,13 @@ class OpenAPIParser::SchemaValidator
           end
         end
 
+        # 3.1: standalone numeric upper bound, mirror of exclusiveMinimum.
+        if schema.exclusiveMaximum.is_a?(Numeric) && value >= schema.exclusiveMaximum
+          raise OpenAPIParser::MoreThanExclusiveMaximum.new(value, reference)
+        end
+
         if schema.maximum
-          if schema.exclusiveMaximum && value >= schema.maximum
+          if schema.exclusiveMaximum == true && value >= schema.maximum
             raise OpenAPIParser::MoreThanExclusiveMaximum.new(value, reference)
           elsif value > schema.maximum
             raise OpenAPIParser::MoreThanMaximum.new(value, reference)

--- a/lib/openapi_parser/schema_validator/minimum_maximum.rb
+++ b/lib/openapi_parser/schema_validator/minimum_maximum.rb
@@ -4,8 +4,9 @@ class OpenAPIParser::SchemaValidator
     # @param [Object] value
     # @param [OpenAPIParser::Schemas::Schema] schema
     def check_minimum_maximum(value, schema)
-      include_min_max = schema.minimum || schema.maximum
-      return [value, nil] unless include_min_max
+      has_min_or_max = schema.minimum || schema.maximum
+      has_numeric_exclusive_min = schema.exclusiveMinimum.is_a?(Numeric)
+      return [value, nil] unless has_min_or_max || has_numeric_exclusive_min
 
       validate(value, schema)
       [value, nil]
@@ -18,8 +19,14 @@ class OpenAPIParser::SchemaValidator
       def validate(value, schema)
         reference = schema.object_reference
 
+        # 3.1: exclusiveMinimum is a standalone numeric bound.
+        if schema.exclusiveMinimum.is_a?(Numeric) && value <= schema.exclusiveMinimum
+          raise OpenAPIParser::LessThanExclusiveMinimum.new(value, reference)
+        end
+
         if schema.minimum
-          if schema.exclusiveMinimum && value <= schema.minimum
+          # 3.0: exclusiveMinimum is a Boolean modifier on `minimum`.
+          if schema.exclusiveMinimum == true && value <= schema.minimum
             raise OpenAPIParser::LessThanExclusiveMinimum.new(value, reference)
           elsif value < schema.minimum
             raise OpenAPIParser::LessThanMinimum.new(value, reference)

--- a/lib/openapi_parser/schemas/openapi.rb
+++ b/lib/openapi_parser/schemas/openapi.rb
@@ -21,6 +21,19 @@ module OpenAPIParser::Schemas
     #   @return [String, nil]
     openapi_attr_values :openapi
 
+    # @return [Symbol] :v3_0 / :v3_1 / :unknown
+    def openapi_version
+      return :unknown unless openapi.is_a?(String)
+
+      if openapi.start_with?('3.0')
+        :v3_0
+      elsif openapi.start_with?('3.1')
+        :v3_1
+      else
+        :unknown
+      end
+    end
+
     # @!attribute [r] paths
     #   @return [Paths, nil]
     openapi_attr_object :paths, Paths, reference: false

--- a/lib/openapi_parser/spec_validator.rb
+++ b/lib/openapi_parser/spec_validator.rb
@@ -1,0 +1,55 @@
+require_relative 'spec_validator/spec_violation'
+require_relative 'spec_validator/rule'
+require_relative 'spec_validator/rules/exclusive_minimum'
+
+module OpenAPIParser
+  class SpecViolationError < OpenAPIError
+    attr_reader :violations
+
+    def initialize(violations)
+      @violations = violations
+      super(nil)
+    end
+
+    def message
+      @violations.map(&:to_s).join("\n")
+    end
+  end
+
+  class SpecValidator
+    def self.run(root)
+      new(root).run
+    end
+
+    def self.run!(root, policy:)
+      return if policy == :silent
+
+      violations = run(root)
+      return if violations.empty?
+
+      case policy
+      when :warn
+        violations.each { |v| warn(v.to_s) }
+      when :raise
+        raise OpenAPIParser::SpecViolationError.new(violations)
+      end
+    end
+
+    def initialize(root)
+      @root = root
+      @version = root.openapi_version
+    end
+
+    def run
+      rules.flat_map { |klass| klass.new(@version).check(@root) }
+    end
+
+    private
+
+      def rules
+        [
+          Rules::ExclusiveMinimum,
+        ]
+      end
+  end
+end

--- a/lib/openapi_parser/spec_validator.rb
+++ b/lib/openapi_parser/spec_validator.rb
@@ -1,6 +1,7 @@
 require_relative 'spec_validator/spec_violation'
 require_relative 'spec_validator/rule'
 require_relative 'spec_validator/rules/exclusive_minimum'
+require_relative 'spec_validator/rules/exclusive_maximum'
 
 module OpenAPIParser
   class SpecViolationError < OpenAPIError
@@ -49,6 +50,7 @@ module OpenAPIParser
       def rules
         [
           Rules::ExclusiveMinimum,
+          Rules::ExclusiveMaximum,
         ]
       end
   end

--- a/lib/openapi_parser/spec_validator/rule.rb
+++ b/lib/openapi_parser/spec_validator/rule.rb
@@ -1,0 +1,55 @@
+module OpenAPIParser
+  class SpecValidator
+    class Rule
+      def self.rule_name
+        name
+          .split('::')
+          .last
+          .gsub(/([A-Z])/) { "_#{Regexp.last_match(1).downcase}" }
+          .sub(/^_/, '')
+          .to_sym
+      end
+
+      def initialize(version)
+        @version = version
+      end
+
+      attr_reader :version
+
+      def check(_root)
+        raise NotImplementedError
+      end
+
+      private
+
+        def violation(path:, message:)
+          OpenAPIParser::SpecViolation.new(
+            message: message,
+            path: path,
+            rule_name: self.class.rule_name,
+          )
+        end
+
+        def each_schema(root, &block)
+          return enum_for(:each_schema, root) unless block
+
+          visited = {}
+          walk(root, visited) do |node|
+            yield node if node.is_a?(OpenAPIParser::Schemas::Schema)
+          end
+        end
+
+        def walk(node, visited, &block)
+          return unless node.respond_to?(:_openapi_all_child_objects)
+          return if visited[node.object_id]
+
+          visited[node.object_id] = true
+          block.call(node)
+
+          node._openapi_all_child_objects.each_value do |child|
+            walk(child, visited, &block)
+          end
+        end
+    end
+  end
+end

--- a/lib/openapi_parser/spec_validator/rules/exclusive_maximum.rb
+++ b/lib/openapi_parser/spec_validator/rules/exclusive_maximum.rb
@@ -1,0 +1,35 @@
+module OpenAPIParser
+  class SpecValidator
+    module Rules
+      class ExclusiveMaximum < Rule
+        def check(root)
+          return [] if version == :unknown
+
+          violations = []
+          each_schema(root) do |schema|
+            value = schema.exclusiveMaximum
+            next if value.nil?
+
+            case version
+            when :v3_0
+              if value.is_a?(Numeric)
+                violations << violation(
+                  path: schema.object_reference,
+                  message: 'numeric exclusiveMaximum is a 3.1-only form; in 3.0 use a Boolean modifier paired with `maximum`',
+                )
+              end
+            when :v3_1
+              if value == true || value == false
+                violations << violation(
+                  path: schema.object_reference,
+                  message: 'Boolean exclusiveMaximum is a 3.0-only form; in 3.1 use a standalone numeric bound',
+                )
+              end
+            end
+          end
+          violations
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_parser/spec_validator/rules/exclusive_minimum.rb
+++ b/lib/openapi_parser/spec_validator/rules/exclusive_minimum.rb
@@ -12,7 +12,7 @@ module OpenAPIParser
 
             case version
             when :v3_0
-              if value.is_a?(Numeric) && !value.is_a?(TrueClass) && !value.is_a?(FalseClass)
+              if value.is_a?(Numeric)
                 violations << violation(
                   path: schema.object_reference,
                   message: 'numeric exclusiveMinimum is a 3.1-only form; in 3.0 use a Boolean modifier paired with `minimum`',

--- a/lib/openapi_parser/spec_validator/rules/exclusive_minimum.rb
+++ b/lib/openapi_parser/spec_validator/rules/exclusive_minimum.rb
@@ -1,0 +1,35 @@
+module OpenAPIParser
+  class SpecValidator
+    module Rules
+      class ExclusiveMinimum < Rule
+        def check(root)
+          return [] if version == :unknown
+
+          violations = []
+          each_schema(root) do |schema|
+            value = schema.exclusiveMinimum
+            next if value.nil?
+
+            case version
+            when :v3_0
+              if value.is_a?(Numeric) && !value.is_a?(TrueClass) && !value.is_a?(FalseClass)
+                violations << violation(
+                  path: schema.object_reference,
+                  message: 'numeric exclusiveMinimum is a 3.1-only form; in 3.0 use a Boolean modifier paired with `minimum`',
+                )
+              end
+            when :v3_1
+              if value == true || value == false
+                violations << violation(
+                  path: schema.object_reference,
+                  message: 'Boolean exclusiveMinimum is a 3.0-only form; in 3.1 use a standalone numeric bound',
+                )
+              end
+            end
+          end
+          violations
+        end
+      end
+    end
+  end
+end

--- a/lib/openapi_parser/spec_validator/spec_violation.rb
+++ b/lib/openapi_parser/spec_validator/spec_violation.rb
@@ -1,0 +1,11 @@
+module OpenAPIParser
+  class SpecValidator
+    SpecViolation = Struct.new(:message, :path, :rule_name, keyword_init: true) do
+      def to_s
+        "[#{rule_name}] #{path}: #{message}"
+      end
+    end
+  end
+
+  SpecViolation = SpecValidator::SpecViolation
+end

--- a/sig/openapi_parser.rbs
+++ b/sig/openapi_parser.rbs
@@ -14,6 +14,8 @@ module OpenAPIParser
   module Schemas
     class OpenAPI
       def initialize: (Hash[bot, bot] hash, untyped config, uri: OpenAPIParser::readable_uri?, schema_registry: Hash[bot, bot]) -> OpenAPIParser::Schemas::OpenAPI
+      def openapi: () -> String?
+      def openapi_version: () -> (:v3_0 | :v3_1 | :unknown)
     end
   end
 end

--- a/sig/openapi_parser/config.rbs
+++ b/sig/openapi_parser/config.rbs
@@ -15,6 +15,7 @@ module OpenAPIParser
     def expand_reference: -> bool
     def strict_response_validation: -> bool
     def strict_reference_validation: -> bool
+    def strict_specification_version: -> (:silent | :warn | :raise)
     def validate_header: -> bool
     def request_validator_options: -> OpenAPIParser::SchemaValidator::Options
     def response_validate_options: -> OpenAPIParser::SchemaValidator::ResponseValidateOptions

--- a/sig/openapi_parser/config.rbs
+++ b/sig/openapi_parser/config.rbs
@@ -15,6 +15,7 @@ module OpenAPIParser
     def expand_reference: -> bool
     def strict_response_validation: -> bool
     def strict_reference_validation: -> bool
+    KNOWN_STRICT_SPECIFICATION_VERSION_VALUES: Array[Symbol]
     def strict_specification_version: -> (:silent | :warn | :raise)
     def validate_header: -> bool
     def request_validator_options: -> OpenAPIParser::SchemaValidator::Options

--- a/sig/openapi_parser/spec_validator.rbs
+++ b/sig/openapi_parser/spec_validator.rbs
@@ -40,6 +40,10 @@ module OpenAPIParser
       class ExclusiveMinimum < Rule
         def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
       end
+
+      class ExclusiveMaximum < Rule
+        def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
+      end
     end
   end
 

--- a/sig/openapi_parser/spec_validator.rbs
+++ b/sig/openapi_parser/spec_validator.rbs
@@ -1,0 +1,47 @@
+module OpenAPIParser
+  class SpecViolationError < OpenAPIError
+    @violations: Array[OpenAPIParser::SpecValidator::SpecViolation]
+    attr_reader violations: Array[OpenAPIParser::SpecValidator::SpecViolation]
+
+    def initialize: (Array[OpenAPIParser::SpecValidator::SpecViolation] violations) -> void
+    def message: () -> String
+  end
+
+  class SpecValidator
+    @root: OpenAPIParser::Schemas::OpenAPI
+    @version: (:v3_0 | :v3_1 | :unknown)
+
+    def self.run: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecViolation]
+    def self.run!: (OpenAPIParser::Schemas::OpenAPI root, policy: (:silent | :warn | :raise)) -> void
+    def initialize: (OpenAPIParser::Schemas::OpenAPI root) -> void
+    def run: () -> Array[SpecViolation]
+    private def rules: () -> Array[singleton(Rule)]
+
+    class SpecViolation < ::Struct[untyped]
+      attr_accessor message: String
+      attr_accessor path: String
+      attr_accessor rule_name: Symbol
+      def to_s: () -> String
+    end
+
+    class Rule
+      @version: (:v3_0 | :v3_1 | :unknown)
+      attr_reader version: (:v3_0 | :v3_1 | :unknown)
+
+      def self.rule_name: () -> Symbol
+      def initialize: ((:v3_0 | :v3_1 | :unknown) version) -> void
+      def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecViolation]
+      private def violation: (path: String, message: String) -> SpecViolation
+      private def each_schema: (untyped root) ?{ (untyped) -> void } -> untyped
+      private def walk: (untyped node, Hash[Integer, bool] visited) { (untyped) -> void } -> void
+    end
+
+    module Rules
+      class ExclusiveMinimum < Rule
+        def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
+      end
+    end
+  end
+
+  SpecViolation: singleton(SpecValidator::SpecViolation)
+end

--- a/spec/data/openapi_3_1/exclusive_maximum_30.yaml
+++ b/spec/data/openapi_3_1/exclusive_maximum_30.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: Pricing API
+  version: '1.0'
+paths:
+  /quotes:
+    post:
+      summary: Request a price quote
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Quote:
+      type: object
+      properties:
+        discountPercent:
+          type: number
+          exclusiveMaximum: 100

--- a/spec/data/openapi_3_1/exclusive_maximum_31.yaml
+++ b/spec/data/openapi_3_1/exclusive_maximum_31.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Pricing API
+  version: '1.0'
+paths:
+  /quotes:
+    post:
+      summary: Request a price quote
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Quote:
+      type: object
+      properties:
+        discountPercent:
+          type: number
+          exclusiveMaximum: 100

--- a/spec/data/openapi_3_1/exclusive_minimum_30.yaml
+++ b/spec/data/openapi_3_1/exclusive_minimum_30.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: Membership API
+  version: '1.0'
+paths:
+  /members:
+    post:
+      summary: Register a member
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Member'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Member:
+      type: object
+      properties:
+        age:
+          type: integer
+          exclusiveMinimum: 0

--- a/spec/data/openapi_3_1/exclusive_minimum_31.yaml
+++ b/spec/data/openapi_3_1/exclusive_minimum_31.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Membership API
+  version: '1.0'
+paths:
+  /members:
+    post:
+      summary: Register a member
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Member'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Member:
+      type: object
+      properties:
+        age:
+          type: integer
+          exclusiveMinimum: 0

--- a/spec/openapi_parser/config_spec.rb
+++ b/spec/openapi_parser/config_spec.rb
@@ -28,5 +28,16 @@ RSpec.describe OpenAPIParser::Config do
         expect(config.strict_specification_version).to eq :raise
       end
     end
+
+    context 'when set to an unrecognized value' do
+      it 'warns and falls back to :silent' do
+        config = OpenAPIParser::Config.new(
+          strict_reference_validation: false,
+          strict_specification_version: :bogus,
+        )
+        expect { expect(config.strict_specification_version).to eq :silent }
+          .to output(/unknown strict_specification_version.*:bogus.*falling back to :silent/).to_stderr
+      end
+    end
   end
 end

--- a/spec/openapi_parser/config_spec.rb
+++ b/spec/openapi_parser/config_spec.rb
@@ -3,15 +3,30 @@ require_relative '../spec_helper'
 RSpec.describe OpenAPIParser::Config do
   describe '#strict_specification_version' do
     context 'when the option is not provided' do
-      it 'defaults to :silent'
+      it 'defaults to :silent' do
+        config = OpenAPIParser::Config.new(strict_reference_validation: false)
+        expect(config.strict_specification_version).to eq :silent
+      end
     end
 
     context 'when set to :warn' do
-      it 'returns :warn'
+      it 'returns :warn' do
+        config = OpenAPIParser::Config.new(
+          strict_reference_validation: false,
+          strict_specification_version: :warn,
+        )
+        expect(config.strict_specification_version).to eq :warn
+      end
     end
 
     context 'when set to :raise' do
-      it 'returns :raise'
+      it 'returns :raise' do
+        config = OpenAPIParser::Config.new(
+          strict_reference_validation: false,
+          strict_specification_version: :raise,
+        )
+        expect(config.strict_specification_version).to eq :raise
+      end
     end
   end
 end

--- a/spec/openapi_parser/config_spec.rb
+++ b/spec/openapi_parser/config_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../spec_helper'
+
+RSpec.describe OpenAPIParser::Config do
+  describe '#strict_specification_version' do
+    context 'when the option is not provided' do
+      it 'defaults to :silent'
+    end
+
+    context 'when set to :warn' do
+      it 'returns :warn'
+    end
+
+    context 'when set to :raise' do
+      it 'returns :raise'
+    end
+  end
+end

--- a/spec/openapi_parser/schema_validator/integer_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/integer_validator_spec.rb
@@ -123,15 +123,30 @@ RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
     end
 
     context 'with a value strictly greater than exclusiveMinimum' do
-      it 'passes validation'
+      let(:params) { { 'my_integer' => 11 } }
+      it 'passes validation' do
+        expect(subject).to eq({ 'my_integer' => 11 })
+      end
     end
 
     context 'with a value equal to exclusiveMinimum' do
-      it 'raises LessThanExclusiveMinimum'
+      let(:params) { { 'my_integer' => 10 } }
+      it 'raises LessThanExclusiveMinimum' do
+        expect { subject }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::LessThanExclusiveMinimum)
+          expect(e.message).to end_with('10 cannot be less than or equal to exclusive minimum value')
+        end
+      end
     end
 
     context 'with a value less than exclusiveMinimum' do
-      it 'raises LessThanExclusiveMinimum'
+      let(:params) { { 'my_integer' => 9 } }
+      it 'raises LessThanExclusiveMinimum' do
+        expect { subject }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::LessThanExclusiveMinimum)
+          expect(e.message).to end_with('9 cannot be less than or equal to exclusive minimum value')
+        end
+      end
     end
   end
 

--- a/spec/openapi_parser/schema_validator/integer_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/integer_validator_spec.rb
@@ -109,6 +109,32 @@ RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
     end
   end
 
+  describe 'validate integer 3.1-style numeric exclusiveMinimum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          exclusiveMinimum: 10,
+        },
+      }
+    end
+
+    context 'with a value strictly greater than exclusiveMinimum' do
+      it 'passes validation'
+    end
+
+    context 'with a value equal to exclusiveMinimum' do
+      it 'raises LessThanExclusiveMinimum'
+    end
+
+    context 'with a value less than exclusiveMinimum' do
+      it 'raises LessThanExclusiveMinimum'
+    end
+  end
+
   describe 'validate integer exclusiveMinimum value' do
     subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
 

--- a/spec/openapi_parser/schema_validator/integer_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator/integer_validator_spec.rb
@@ -109,6 +109,47 @@ RSpec.describe OpenAPIParser::SchemaValidator::IntegerValidator do
     end
   end
 
+  describe 'validate integer 3.1-style numeric exclusiveMaximum value' do
+    subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
+
+    let(:params) { {} }
+    let(:replace_schema) do
+      {
+        my_integer: {
+          type: 'integer',
+          exclusiveMaximum: 10,
+        },
+      }
+    end
+
+    context 'with a value strictly less than exclusiveMaximum' do
+      let(:params) { { 'my_integer' => 9 } }
+      it 'passes validation' do
+        expect(subject).to eq({ 'my_integer' => 9 })
+      end
+    end
+
+    context 'with a value equal to exclusiveMaximum' do
+      let(:params) { { 'my_integer' => 10 } }
+      it 'raises MoreThanExclusiveMaximum' do
+        expect { subject }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::MoreThanExclusiveMaximum)
+          expect(e.message).to end_with('10 cannot be more than or equal to exclusive maximum value')
+        end
+      end
+    end
+
+    context 'with a value greater than exclusiveMaximum' do
+      let(:params) { { 'my_integer' => 11 } }
+      it 'raises MoreThanExclusiveMaximum' do
+        expect { subject }.to raise_error do |e|
+          expect(e).to be_kind_of(OpenAPIParser::MoreThanExclusiveMaximum)
+          expect(e.message).to end_with('11 cannot be more than or equal to exclusive maximum value')
+        end
+      end
+    end
+  end
+
   describe 'validate integer 3.1-style numeric exclusiveMinimum value' do
     subject { OpenAPIParser::SchemaValidator.validate(params, target_schema, options) }
 

--- a/spec/openapi_parser/schemas/open_api_spec.rb
+++ b/spec/openapi_parser/schemas/open_api_spec.rb
@@ -23,36 +23,58 @@ RSpec.describe OpenAPIParser::Schemas::OpenAPI do
   end
 
   describe '#openapi_version' do
+    def parse_with_openapi_field(value, present: true)
+      schema = { 'info' => { 'title' => 'test', 'version' => '1.0' }, 'paths' => {} }
+      schema['openapi'] = value if present
+      OpenAPIParser.parse(schema, strict_reference_validation: false)
+    end
+
     context 'with a typical 3.0.x version like "3.0.0"' do
-      it 'returns :v3_0'
+      it 'returns :v3_0' do
+        expect(parse_with_openapi_field('3.0.0').openapi_version).to eq :v3_0
+      end
     end
 
     context 'with a typical 3.1.x version like "3.1.0"' do
-      it 'returns :v3_1'
+      it 'returns :v3_1' do
+        expect(parse_with_openapi_field('3.1.0').openapi_version).to eq :v3_1
+      end
     end
 
     context 'with a minor-only version "3.0"' do
-      it 'returns :v3_0'
+      it 'returns :v3_0' do
+        expect(parse_with_openapi_field('3.0').openapi_version).to eq :v3_0
+      end
     end
 
     context 'with a minor-only version "3.1"' do
-      it 'returns :v3_1'
+      it 'returns :v3_1' do
+        expect(parse_with_openapi_field('3.1').openapi_version).to eq :v3_1
+      end
     end
 
     context 'with a prerelease tag like "3.0.0-rc1"' do
-      it 'returns :v3_0 by prefix match'
+      it 'returns :v3_0 by prefix match' do
+        expect(parse_with_openapi_field('3.0.0-rc1').openapi_version).to eq :v3_0
+      end
     end
 
     context 'with an unknown major version like "4.0.0"' do
-      it 'returns :unknown'
+      it 'returns :unknown' do
+        expect(parse_with_openapi_field('4.0.0').openapi_version).to eq :unknown
+      end
     end
 
     context 'when the openapi field is missing' do
-      it 'returns :unknown'
+      it 'returns :unknown' do
+        expect(parse_with_openapi_field(nil, present: false).openapi_version).to eq :unknown
+      end
     end
 
     context 'with a non-string openapi field' do
-      it 'returns :unknown'
+      it 'returns :unknown' do
+        expect(parse_with_openapi_field(31).openapi_version).to eq :unknown
+      end
     end
   end
 end

--- a/spec/openapi_parser/schemas/open_api_spec.rb
+++ b/spec/openapi_parser/schemas/open_api_spec.rb
@@ -21,4 +21,38 @@ RSpec.describe OpenAPIParser::Schemas::OpenAPI do
   describe '#components' do
     it { expect(subject.components).not_to eq nil }
   end
+
+  describe '#openapi_version' do
+    context 'with a typical 3.0.x version like "3.0.0"' do
+      it 'returns :v3_0'
+    end
+
+    context 'with a typical 3.1.x version like "3.1.0"' do
+      it 'returns :v3_1'
+    end
+
+    context 'with a minor-only version "3.0"' do
+      it 'returns :v3_0'
+    end
+
+    context 'with a minor-only version "3.1"' do
+      it 'returns :v3_1'
+    end
+
+    context 'with a prerelease tag like "3.0.0-rc1"' do
+      it 'returns :v3_0 by prefix match'
+    end
+
+    context 'with an unknown major version like "4.0.0"' do
+      it 'returns :unknown'
+    end
+
+    context 'when the openapi field is missing' do
+      it 'returns :unknown'
+    end
+
+    context 'with a non-string openapi field' do
+      it 'returns :unknown'
+    end
+  end
 end

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -1,15 +1,62 @@
 require_relative '../../spec_helper'
 
 RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
+  DATA_DIR = './spec/data/openapi_3_1'.freeze
+
+  def load_doc(file, policy)
+    OpenAPIParser.load(
+      "#{DATA_DIR}/#{file}",
+      strict_reference_validation: false,
+      strict_specification_version: policy,
+    )
+  end
+
+  def capture_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+
+  def expect_mismatch_warns(file, rule_names)
+    stderr = capture_stderr { load_doc(file, :warn) }
+    rule_names.each { |rule_name| expect(stderr).to include("[#{rule_name}]") }
+    expect(stderr.lines.size).to eq rule_names.size
+  end
+
+  def expect_mismatch_raises(file, rule_names)
+    expect { load_doc(file, :raise) }
+      .to raise_error(OpenAPIParser::SpecViolationError) do |error|
+        expect(error.violations.map(&:rule_name)).to match_array(rule_names)
+      end
+  end
+
+  def expect_clean(file)
+    expect(OpenAPIParser::SpecValidator.run(load_doc(file, :silent))).to eq []
+    expect { load_doc(file, :warn) }.not_to output.to_stderr
+    expect { load_doc(file, :raise) }.not_to raise_error
+  end
+
   describe 'strict_specification_version :silent (default)' do
-    it 'never warns or raises even when the document contains violations'
+    it 'never warns or raises even when the document contains violations' do
+      expect { load_doc('exclusive_minimum_30.yaml', :silent) }.not_to output.to_stderr
+      expect { load_doc('exclusive_minimum_30.yaml', :silent) }.not_to raise_error
+    end
   end
 
   describe 'exclusiveMinimum (3.0 Boolean modifier vs 3.1 numeric bound)' do
-    it 'warns on the version-mismatched document under :warn'
+    it 'warns on the version-mismatched document under :warn' do
+      expect_mismatch_warns('exclusive_minimum_30.yaml', [:exclusive_minimum])
+    end
 
-    it 'raises SpecViolationError on the version-mismatched document under :raise'
+    it 'raises SpecViolationError on the version-mismatched document under :raise' do
+      expect_mismatch_raises('exclusive_minimum_30.yaml', [:exclusive_minimum])
+    end
 
-    it 'stays clean on the correctly-versioned document'
+    it 'stays clean on the correctly-versioned document' do
+      expect_clean('exclusive_minimum_31.yaml')
+    end
   end
 end

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+
+RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
+  describe 'strict_specification_version :silent (default)' do
+    it 'never warns or raises even when the document contains violations'
+  end
+
+  describe 'exclusiveMinimum (3.0 Boolean modifier vs 3.1 numeric bound)' do
+    it 'warns on the version-mismatched document under :warn'
+
+    it 'raises SpecViolationError on the version-mismatched document under :raise'
+
+    it 'stays clean on the correctly-versioned document'
+  end
+end

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -59,4 +59,18 @@ RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
       expect_clean('exclusive_minimum_31.yaml')
     end
   end
+
+  describe 'exclusiveMaximum (3.0 Boolean modifier vs 3.1 numeric bound)' do
+    it 'warns on the version-mismatched document under :warn' do
+      expect_mismatch_warns('exclusive_maximum_30.yaml', [:exclusive_maximum])
+    end
+
+    it 'raises SpecViolationError on the version-mismatched document under :raise' do
+      expect_mismatch_raises('exclusive_maximum_30.yaml', [:exclusive_maximum])
+    end
+
+    it 'stays clean on the correctly-versioned document' do
+      expect_clean('exclusive_maximum_31.yaml')
+    end
+  end
 end

--- a/spec/openapi_parser/spec_validator/rules/exclusive_maximum_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/exclusive_maximum_spec.rb
@@ -1,0 +1,73 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe OpenAPIParser::SpecValidator::Rules::ExclusiveMaximum do
+  def schema_with_exclusive_maximum(openapi_version_string, exclusive_maximum_value, maximum_value: nil)
+    schema_payload = { 'type' => 'integer', 'exclusiveMaximum' => exclusive_maximum_value }
+    schema_payload['maximum'] = maximum_value if maximum_value
+    raw = {
+      'openapi' => openapi_version_string,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Sample' => schema_payload } },
+    }
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def run_rule_for(root)
+    OpenAPIParser::SpecValidator::Rules::ExclusiveMaximum.new(root.openapi_version).check(root)
+  end
+
+  context 'with a 3.0 document using a 3.0-style boolean exclusiveMaximum' do
+    it 'reports no violation' do
+      root = schema_with_exclusive_maximum('3.0.0', true, maximum_value: 5)
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.1 document using a 3.1-style numeric exclusiveMaximum' do
+    it 'reports no violation' do
+      root = schema_with_exclusive_maximum('3.1.0', 5)
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.0 document using a 3.1-style numeric exclusiveMaximum' do
+    it 'reports one violation pointing at the offending schema' do
+      root = schema_with_exclusive_maximum('3.0.0', 5)
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.rule_name).to eq :exclusive_maximum
+      expect(violations.first.message).to include('numeric exclusiveMaximum')
+    end
+  end
+
+  context 'with a 3.1 document using a 3.0-style boolean exclusiveMaximum' do
+    it 'reports one violation pointing at the offending schema' do
+      root = schema_with_exclusive_maximum('3.1.0', true, maximum_value: 5)
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.message).to include('Boolean exclusiveMaximum')
+    end
+  end
+
+  context 'with an :unknown version document containing exclusiveMaximum' do
+    it 'reports no violation (rule skipped)' do
+      root = schema_with_exclusive_maximum('4.0.0', 5)
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a schema that has no exclusiveMaximum' do
+    it 'reports no violation' do
+      raw = {
+        'openapi' => '3.0.0',
+        'info' => { 'title' => 'test', 'version' => '1.0' },
+        'paths' => {},
+        'components' => { 'schemas' => { 'Sample' => { 'type' => 'integer' } } },
+      }
+      root = OpenAPIParser.parse(raw, strict_reference_validation: false)
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+end

--- a/spec/openapi_parser/spec_validator/rules/exclusive_minimum_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/exclusive_minimum_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ExclusiveMinimum' do
+  context 'with a 3.0 document using a 3.0-style boolean exclusiveMinimum' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.1 document using a 3.1-style numeric exclusiveMinimum' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.0 document using a 3.1-style numeric exclusiveMinimum' do
+    it 'reports one violation pointing at the offending schema'
+  end
+
+  context 'with a 3.1 document using a 3.0-style boolean exclusiveMinimum' do
+    it 'reports one violation pointing at the offending schema'
+  end
+
+  context 'with an :unknown version document containing exclusiveMinimum' do
+    it 'reports no violation (rule skipped)'
+  end
+
+  context 'with a schema that has no exclusiveMinimum' do
+    it 'reports no violation'
+  end
+end

--- a/spec/openapi_parser/spec_validator/rules/exclusive_minimum_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/exclusive_minimum_spec.rb
@@ -1,27 +1,74 @@
 require_relative '../../../spec_helper'
 
-RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ExclusiveMinimum' do
+RSpec.describe OpenAPIParser::SpecValidator::Rules::ExclusiveMinimum do
+  def schema_with_exclusive_minimum(openapi_version_string, exclusive_minimum_value, minimum_value: nil)
+    schema_payload = { 'type' => 'integer', 'exclusiveMinimum' => exclusive_minimum_value }
+    schema_payload['minimum'] = minimum_value if minimum_value
+    raw = {
+      'openapi' => openapi_version_string,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Sample' => schema_payload } },
+    }
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def run_rule_for(root)
+    OpenAPIParser::SpecValidator::Rules::ExclusiveMinimum.new(root.openapi_version).check(root)
+  end
+
   context 'with a 3.0 document using a 3.0-style boolean exclusiveMinimum' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = schema_with_exclusive_minimum('3.0.0', true, minimum_value: 5)
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.1 document using a 3.1-style numeric exclusiveMinimum' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = schema_with_exclusive_minimum('3.1.0', 5)
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.0 document using a 3.1-style numeric exclusiveMinimum' do
-    it 'reports one violation pointing at the offending schema'
+    it 'reports one violation pointing at the offending schema' do
+      root = schema_with_exclusive_minimum('3.0.0', 5)
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.rule_name).to eq :exclusive_minimum
+      expect(violations.first.message).to include('numeric exclusiveMinimum')
+    end
   end
 
   context 'with a 3.1 document using a 3.0-style boolean exclusiveMinimum' do
-    it 'reports one violation pointing at the offending schema'
+    it 'reports one violation pointing at the offending schema' do
+      root = schema_with_exclusive_minimum('3.1.0', true, minimum_value: 5)
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.message).to include('Boolean exclusiveMinimum')
+    end
   end
 
   context 'with an :unknown version document containing exclusiveMinimum' do
-    it 'reports no violation (rule skipped)'
+    it 'reports no violation (rule skipped)' do
+      root = schema_with_exclusive_minimum('4.0.0', 5)
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a schema that has no exclusiveMinimum' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      raw = {
+        'openapi' => '3.0.0',
+        'info' => { 'title' => 'test', 'version' => '1.0' },
+        'paths' => {},
+        'components' => { 'schemas' => { 'Sample' => { 'type' => 'integer' } } },
+      }
+      root = OpenAPIParser.parse(raw, strict_reference_validation: false)
+      expect(run_rule_for(root)).to eq []
+    end
   end
 end

--- a/spec/openapi_parser/spec_validator_spec.rb
+++ b/spec/openapi_parser/spec_validator_spec.rb
@@ -1,39 +1,105 @@
 require_relative '../spec_helper'
 
 RSpec.describe 'OpenAPIParser::SpecValidator' do
+  def parse_root(raw)
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def clean_root(version = '3.0.0')
+    parse_root(
+      'openapi' => version,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+    )
+  end
+
   describe '.run' do
     context 'with a root that has no spec-version-specific issues' do
-      it 'returns an empty array'
+      it 'returns an empty array' do
+        expect(OpenAPIParser::SpecValidator.run(clean_root)).to eq []
+      end
     end
 
     context 'with a root whose openapi field is unrecognized' do
-      it 'returns an empty array (version-specific rules are skipped)'
+      it 'returns an empty array (version-specific rules are skipped)' do
+        expect(OpenAPIParser::SpecValidator.run(clean_root('4.0.0'))).to eq []
+      end
     end
 
     context 'with violations detected by a registered rule' do
-      it 'returns the collected SpecViolation list'
+      it 'returns the collected SpecViolation list' do
+        root = parse_root(
+          'openapi' => '3.0.0',
+          'info' => { 'title' => 'test', 'version' => '1.0' },
+          'paths' => {},
+          'components' => {
+            'schemas' => {
+              'Sample' => { 'type' => 'integer', 'exclusiveMinimum' => 5 },
+            },
+          },
+        )
+        violations = OpenAPIParser::SpecValidator.run(root)
+        expect(violations.size).to eq 1
+        expect(violations.first).to be_a(OpenAPIParser::SpecViolation)
+      end
     end
   end
 
   describe '.run!' do
     context 'with policy :silent' do
-      it 'returns nil without running validation'
+      it 'returns nil without running validation' do
+        expect(OpenAPIParser::SpecValidator.run!(clean_root, policy: :silent)).to be_nil
+      end
     end
 
     context 'with policy :warn and violations present' do
-      it 'emits one warning per violation to stderr'
+      it 'emits one warning per violation to stderr' do
+        root = parse_root(
+          'openapi' => '3.0.0',
+          'info' => { 'title' => 'test', 'version' => '1.0' },
+          'paths' => {},
+          'components' => {
+            'schemas' => {
+              'Sample' => { 'type' => 'integer', 'exclusiveMinimum' => 5 },
+            },
+          },
+        )
+        expect { OpenAPIParser::SpecValidator.run!(root, policy: :warn) }
+          .to output(/exclusive_minimum/).to_stderr
+      end
     end
 
     context 'with policy :warn and no violations' do
-      it 'produces no output'
+      it 'produces no output' do
+        expect { OpenAPIParser::SpecValidator.run!(clean_root, policy: :warn) }
+          .not_to output.to_stderr
+      end
     end
 
     context 'with policy :raise and violations present' do
-      it 'raises SpecViolationError carrying the violations'
+      it 'raises SpecViolationError carrying the violations' do
+        root = parse_root(
+          'openapi' => '3.0.0',
+          'info' => { 'title' => 'test', 'version' => '1.0' },
+          'paths' => {},
+          'components' => {
+            'schemas' => {
+              'Sample' => { 'type' => 'integer', 'exclusiveMinimum' => 5 },
+            },
+          },
+        )
+        expect { OpenAPIParser::SpecValidator.run!(root, policy: :raise) }
+          .to raise_error(OpenAPIParser::SpecViolationError) do |e|
+            expect(e.violations.size).to eq 1
+          end
+      end
     end
 
     context 'with policy :raise and no violations' do
-      it 'does not raise'
+      it 'does not raise' do
+        expect { OpenAPIParser::SpecValidator.run!(clean_root, policy: :raise) }
+          .not_to raise_error
+      end
     end
   end
 end

--- a/spec/openapi_parser/spec_validator_spec.rb
+++ b/spec/openapi_parser/spec_validator_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../spec_helper'
+
+RSpec.describe 'OpenAPIParser::SpecValidator' do
+  describe '.run' do
+    context 'with a root that has no spec-version-specific issues' do
+      it 'returns an empty array'
+    end
+
+    context 'with a root whose openapi field is unrecognized' do
+      it 'returns an empty array (version-specific rules are skipped)'
+    end
+
+    context 'with violations detected by a registered rule' do
+      it 'returns the collected SpecViolation list'
+    end
+  end
+
+  describe '.run!' do
+    context 'with policy :silent' do
+      it 'returns nil without running validation'
+    end
+
+    context 'with policy :warn and violations present' do
+      it 'emits one warning per violation to stderr'
+    end
+
+    context 'with policy :warn and no violations' do
+      it 'produces no output'
+    end
+
+    context 'with policy :raise and violations present' do
+      it 'raises SpecViolationError carrying the violations'
+    end
+
+    context 'with policy :raise and no violations' do
+      it 'does not raise'
+    end
+  end
+end


### PR DESCRIPTION
Continuing the OpenAPI 3.1 work from #191 / #152.

This PR adds these implementations:

- `OpenAPIParser::SpecValidator`: evaluate rules between declared version and actual field usage
  - `ExclusiveMinimum` / `ExclusiveMaximum` rules
- Config key `strict_specification_version` (`:silent` / `:warn` / `:raise`)
- OpenAPI 3.1 style `exclusiveMinimum` / `exclusiveMaximum` runtime validation

## Design

`OpenAPIParser::SpecValidator` runs after parse and detects version mismatches — places where a document's declared OpenAPI version disagrees with the actual field usage. This is the "version-aware reporting" mentioned in #191's scope note.

```
OpenAPIParser.load_hash
  → parse (permissive, as before)
  → SpecValidator.run!(root, policy:)   # one line in load_hash
      → .run(root)                      # pure: returns Array[SpecViolation]
      → dispatch: warn / raise / silent
```

- `SpecValidator.run` is pure — returns violations without side effects (unit-testable)
- `SpecValidator.run!` encapsulates the policy dispatch (warn/raise/silent)
- `Rule` base class provides tree-walking helpers (`each_schema`); each subclass implements `#check(root) → Array[SpecViolation]`
- Adding a new rule = one file in `spec_validator/rules/`, one line in the `rules` array

The parse layer remains permissive: `exclusiveMinimum: 0` is accepted on a 3.0 document.
`SpecValidator` reports the mismatch; whether to act on it is the caller's choice via the config.

## Implementation details

### Config

A new `strict_specification_version` option controls behavior:

| Value | Behavior |
|-------|----------|
| `:silent` (default) | No change — existing behavior is preserved |
| `:warn` | Emits one `Kernel#warn` per violation |
| `:raise` | Raises `OpenAPIParser::SpecViolationError` |

### Rules: `ExclusiveMinimum` / `ExclusiveMaximum`

In 3.0, `exclusiveMinimum` is a Boolean modifier on `minimum` (`exclusiveMinimum: true`). In 3.1, it is a standalone numeric bound (`exclusiveMinimum: 0`). The rules flag the mismatch in both directions. `ExclusiveMaximum` is the mirror.

### Runtime value validation

The runtime validator now handles 3.1-style numeric `exclusiveMinimum` / `exclusiveMaximum` as standalone bounds, dispatching on value type rather than declared version:

```yaml
# 3.1 form — previously ignored, now enforced
schema:
  type: integer
  exclusiveMinimum: 0    # rejects 0, accepts 1+
  exclusiveMaximum: 100  # rejects 100, accepts 99-
```
