### PR TITLE
Support type: "null" for OpenAPI 3.1 schemas (runtime + TypeNullIn30 rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 * support `components.pathItems` so `$ref`s into it resolve, unblocking OpenAPI 3.1 documents that use reusable path items
 * add `SpecValidator` with `strict_specification_version` config (`:silent` / `:warn` / `:raise`) to detect version mismatches between declared OpenAPI version and actual field usage
   * `ExclusiveMinimum` / `ExclusiveMaximum`: detect 3.0 Boolean vs 3.1 numeric form mismatch
+  * `TypeNullIn30`: detect `type: "null"` usage in 3.0 documents (3.1 primitive)
 * support 3.1-style numeric `exclusiveMinimum` / `exclusiveMaximum` in value validation (standalone bound, not a Boolean modifier on `minimum` / `maximum`)
+* support `type: "null"` (3.1 primitive) in value validation
 
 ## 2.3.1 (2025-11-14)
 * add optional date coercion with behavior matching existing datetime coercion

--- a/lib/openapi_parser/schema_validator.rb
+++ b/lib/openapi_parser/schema_validator.rb
@@ -13,6 +13,7 @@ require_relative 'schema_validator/any_of_validator'
 require_relative 'schema_validator/all_of_validator'
 require_relative 'schema_validator/one_of_validator'
 require_relative 'schema_validator/nil_validator'
+require_relative 'schema_validator/null_type_validator'
 require_relative 'schema_validator/unspecified_type_validator'
 
 class OpenAPIParser::SchemaValidator
@@ -116,9 +117,18 @@ class OpenAPIParser::SchemaValidator
         object_validator
       when 'array'
         array_validator
+      when 'null'
+        # 3.1: only nil values are valid here. nil is handled earlier in
+        # this method, so a non-nil value reaching this branch is a type
+        # mismatch that should fail validation.
+        null_type_validator
       else
         unspecified_type_validator
       end
+    end
+
+    def null_type_validator
+      @null_type_validator ||= OpenAPIParser::SchemaValidator::NullTypeValidator.new(self, @coerce_value)
     end
 
     def string_validator

--- a/lib/openapi_parser/schema_validator/nil_validator.rb
+++ b/lib/openapi_parser/schema_validator/nil_validator.rb
@@ -4,6 +4,8 @@ class OpenAPIParser::SchemaValidator
     # @param [OpenAPIParser::Schemas::Schema] schema
     def coerce_and_validate(value, schema, **_keyword_args)
       return [value, nil] if schema.nullable
+      # 3.1: `type: "null"` makes nil the only valid value for the schema.
+      return [value, nil] if schema.type == 'null'
 
       [nil, OpenAPIParser::NotNullError.new(schema.object_reference)]
     end

--- a/lib/openapi_parser/schema_validator/null_type_validator.rb
+++ b/lib/openapi_parser/schema_validator/null_type_validator.rb
@@ -1,0 +1,10 @@
+class OpenAPIParser::SchemaValidator
+  # Validates schemas declared as `type: "null"` (3.1) against non-nil
+  # values. The nil case is short-circuited by NilValidator before this
+  # validator is even picked up.
+  class NullTypeValidator < Base
+    def coerce_and_validate(value, schema, **_keyword_args)
+      OpenAPIParser::ValidateError.build_error_result(value, schema)
+    end
+  end
+end

--- a/lib/openapi_parser/spec_validator.rb
+++ b/lib/openapi_parser/spec_validator.rb
@@ -4,6 +4,7 @@ require_relative 'spec_validator/rules/exclusive_minimum'
 require_relative 'spec_validator/rules/exclusive_maximum'
 require_relative 'spec_validator/rules/nullable_deprecation'
 require_relative 'spec_validator/rules/example_singular_deprecation'
+require_relative 'spec_validator/rules/type_null_in_30'
 
 module OpenAPIParser
   class SpecViolationError < OpenAPIError
@@ -55,6 +56,7 @@ module OpenAPIParser
           Rules::ExclusiveMaximum,
           Rules::NullableDeprecation,
           Rules::ExampleSingularDeprecation,
+          Rules::TypeNullIn30,
         ]
       end
   end

--- a/lib/openapi_parser/spec_validator/rules/type_null_in_30.rb
+++ b/lib/openapi_parser/spec_validator/rules/type_null_in_30.rb
@@ -1,0 +1,26 @@
+module OpenAPIParser
+  class SpecValidator
+    module Rules
+      # `type: "null"` was added by 3.1; 3.0 only allowed the original six
+      # primitive type names. The parse layer accepts the literal anyway,
+      # so we report the mismatch here. Array-form types like
+      # `["string", "null"]` are covered by a separate rule.
+      class TypeNullIn30 < Rule
+        def check(root)
+          return [] unless version == :v3_0
+
+          violations = []
+          each_schema(root) do |schema|
+            next unless schema.type == 'null'
+
+            violations << violation(
+              path: schema.object_reference,
+              message: '`type: "null"` is a 3.1 addition; 3.0 documents have no such primitive',
+            )
+          end
+          violations
+        end
+      end
+    end
+  end
+end

--- a/sig/openapi_parser/spec_validator.rbs
+++ b/sig/openapi_parser/spec_validator.rbs
@@ -52,6 +52,10 @@ module OpenAPIParser
       class ExampleSingularDeprecation < Rule
         def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
       end
+
+      class TypeNullIn30 < Rule
+        def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
+      end
     end
   end
 

--- a/spec/data/openapi_3_1/type_null_30.yaml
+++ b/spec/data/openapi_3_1/type_null_30.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: Telemetry API
+  version: '1.0'
+paths:
+  /readings:
+    get:
+      summary: List sensor readings
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reading'
+components:
+  schemas:
+    Reading:
+      type: object
+      properties:
+        # 3.1 primitive `type: "null"`. 3.0 only knows the original six
+        # primitive names, so this is a spec violation on a 3.0 document.
+        calibration:
+          type: "null"

--- a/spec/data/openapi_3_1/type_null_31.yaml
+++ b/spec/data/openapi_3_1/type_null_31.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Telemetry API
+  version: '1.0'
+paths:
+  /readings:
+    get:
+      summary: List sensor readings
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reading'
+components:
+  schemas:
+    Reading:
+      type: object
+      properties:
+        # 3.1 introduced `type: "null"` as a primitive, so this is legitimate
+        # on a 3.1 document and no violation is expected.
+        calibration:
+          type: "null"

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -101,4 +101,19 @@ RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
       expect_clean('example_keyword_30.yaml')
     end
   end
+
+  describe 'type: "null" (3.1 primitive absent from 3.0)' do
+    it 'warns on the version-mismatched document under :warn' do
+      expect_mismatch_warns('type_null_30.yaml', [:type_null_in30])
+    end
+
+    it 'raises SpecViolationError on the version-mismatched document under :raise' do
+      expect_mismatch_raises('type_null_30.yaml', [:type_null_in30])
+    end
+
+    it 'stays clean on the correctly-versioned document' do
+      expect_clean('type_null_31.yaml')
+    end
+  end
+
 end

--- a/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
@@ -16,19 +16,40 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
   end
 
   context 'with a 3.1 document using type: "null"' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = schema_with_type_null('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.0 document using type: "null"' do
-    it 'reports one violation pointing at the offending schema'
+    it 'reports one violation pointing at the offending schema' do
+      root = schema_with_type_null('3.0.0')
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.rule_name).to eq :type_null_in30
+    end
   end
 
   context 'with a 3.0 document using a normal type' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      raw = {
+        'openapi' => '3.0.0',
+        'info' => { 'title' => 'test', 'version' => '1.0' },
+        'paths' => {},
+        'components' => { 'schemas' => { 'Sample' => { 'type' => 'string' } } },
+      }
+      root = OpenAPIParser.parse(raw, strict_reference_validation: false)
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with an :unknown version document using type: "null"' do
-    it 'reports no violation (rule skipped)'
+    it 'reports no violation (rule skipped)' do
+      root = schema_with_type_null('4.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 end
 
@@ -45,10 +66,17 @@ RSpec.describe 'runtime: type: "null" semantic' do
   end
 
   context 'when value is nil' do
-    it 'passes validation without nullable'
+    it 'passes validation without nullable' do
+      result = OpenAPIParser::SchemaValidator.validate(nil, schema, options)
+      expect(result).to eq nil
+    end
   end
 
   context 'when value is not nil' do
-    it 'raises a type-mismatch error'
+    it 'raises a type-mismatch error' do
+      expect do
+        OpenAPIParser::SchemaValidator.validate('not nil', schema, options)
+      end.to raise_error(OpenAPIParser::ValidateError)
+    end
   end
 end

--- a/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
@@ -1,0 +1,54 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
+  def schema_with_type_null(openapi_version_string)
+    raw = {
+      'openapi' => openapi_version_string,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Sample' => { 'type' => 'null' } } },
+    }
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def run_rule_for(root)
+    OpenAPIParser::SpecValidator::Rules::TypeNullIn30.new(root.openapi_version).check(root)
+  end
+
+  context 'with a 3.1 document using type: "null"' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.0 document using type: "null"' do
+    it 'reports one violation pointing at the offending schema'
+  end
+
+  context 'with a 3.0 document using a normal type' do
+    it 'reports no violation'
+  end
+
+  context 'with an :unknown version document using type: "null"' do
+    it 'reports no violation (rule skipped)'
+  end
+end
+
+RSpec.describe 'runtime: type: "null" semantic' do
+  let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
+  let(:schema) do
+    raw = {
+      'openapi' => '3.1.0',
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Nullable' => { 'type' => 'null' } } },
+    }
+    OpenAPIParser.parse(raw, strict_reference_validation: false).components.schemas['Nullable']
+  end
+
+  context 'when value is nil' do
+    it 'passes validation without nullable'
+  end
+
+  context 'when value is not nil' do
+    it 'raises a type-mismatch error'
+  end
+end


### PR DESCRIPTION
Continuing the OpenAPI 3.1 work from #195 / #152.

OpenAPI 3.1 (via JSON Schema) adds `"null"` as a primitive type name.
In 3.0, nullability was expressed via the `nullable` keyword; `type: "null"` had no meaning.

This PR adds both runtime validation and version-mismatch detection for `type: "null"`.

### Runtime validation

```yaml
# 3.1 document
schema:
  type: "null"
# nil → valid, "hello" → ValidateError
```

The accept side and the reject side live in two different validators,
because of how `SchemaValidator#validator` dispatches:

```ruby
def validator(value, schema)
  # ...
  return nil_validator if value.nil?   # <- every nil value goes here,
                                       #    before the type dispatch below
  case schema.type
  # ...
  when 'null'
    null_type_validator                # <- only non-nil values can reach this
  # ...
end
```

#### Accepting `nil`
happens in the existing `NilValidator`, which handles all nil values regardless of schema type. It now treats `schema.type == "null"` as valid, exactly like the existing `nullable: true` path.

#### Rejecting everything else
happens in the new `NullTypeValidator`. Since nil values are routed to `NilValidator` before the type dispatch, any value reaching the `when 'null'` branch is by construction non-nil.  
So `NullTypeValidator` unconditionally returns a validation error.
Without the new branch, `type: "null"` would fall through to `UnspecifiedTypeValidator` and accept any value.

### SpecValidator rule

`TypeNullIn30` walks all schemas and reports a violation when a 3.0 document uses `type: "null"`.
Array-form types like `["string", "null"]` are covered by a separate rule in a later PR.

```ruby
OpenAPIParser.load(
  'spec.yaml',
  strict_specification_version: :warn,
)
# [TypeNullIn30] #/…/schema — `type: "null"` is a 3.1 addition; 3.0 documents have no such primitive
```
