### PR TITLE
Detect $dynamicRef in OpenAPI 3.0 documents (DynamicRefIn30 rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `TypeNullIn30`: detect `type: "null"` usage in 3.0 documents (3.1 primitive)
   * `WebhooksIn30`: detect root-level `webhooks` usage in 3.0 documents (3.1 addition)
   * `ConstIn30`: detect `const` usage in 3.0 documents (3.1 addition)
+  * `DynamicRefIn30`: detect `$dynamicRef` usage in 3.0 documents (3.1 addition)
 * support 3.1-style numeric `exclusiveMinimum` / `exclusiveMaximum` in value validation (standalone bound, not a Boolean modifier on `minimum` / `maximum`)
 * support `type: "null"` (3.1 primitive) in value validation
 * support root-level `webhooks` (OpenAPI 3.1) in the parse layer

--- a/lib/openapi_parser/spec_validator.rb
+++ b/lib/openapi_parser/spec_validator.rb
@@ -10,6 +10,7 @@ require_relative 'spec_validator/rules/example_singular_deprecation'
 require_relative 'spec_validator/rules/type_null_in_30'
 require_relative 'spec_validator/rules/webhooks_in_30'
 require_relative 'spec_validator/rules/const_in_30'
+require_relative 'spec_validator/rules/dynamic_ref_in_30'
 
 module OpenAPIParser
   class SpecViolationError < OpenAPIError
@@ -67,6 +68,7 @@ module OpenAPIParser
           Rules::TypeNullIn30,
           Rules::WebhooksIn30,
           Rules::ConstIn30,
+          Rules::DynamicRefIn30,
         ]
       end
   end

--- a/lib/openapi_parser/spec_validator/rules/dynamic_ref_in_30.rb
+++ b/lib/openapi_parser/spec_validator/rules/dynamic_ref_in_30.rb
@@ -1,0 +1,25 @@
+module OpenAPIParser
+  class SpecValidator
+    module Rules
+      # `$dynamicRef` is a JSON Schema 2020-12 referencing mechanism that
+      # 3.1 adopted. 3.0 does not recognize it. The parse layer keeps the
+      # value as raw schema data; this rule reports the version mismatch.
+      class DynamicRefIn30 < Rule
+        def check(root)
+          return [] unless version == :v3_0
+
+          violations = []
+          each_schema(root) do |schema|
+            next unless schema.raw_schema.is_a?(Hash) && schema.raw_schema.key?('$dynamicRef')
+
+            violations << violation(
+              path: schema.object_reference,
+              message: '`$dynamicRef` is a 3.1 addition (from JSON Schema 2020-12); 3.0 only knows `$ref`',
+            )
+          end
+          violations
+        end
+      end
+    end
+  end
+end

--- a/sig/openapi_parser/spec_validator.rbs
+++ b/sig/openapi_parser/spec_validator.rbs
@@ -76,6 +76,10 @@ module OpenAPIParser
       class ConstIn30 < Rule
         def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
       end
+
+      class DynamicRefIn30 < Rule
+        def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
+      end
     end
   end
 

--- a/spec/data/openapi_3_1/dynamic_ref_30.yaml
+++ b/spec/data/openapi_3_1/dynamic_ref_30.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Tree API
+  version: '1.0'
+paths:
+  /trees:
+    get:
+      summary: Fetch a tree
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        children:
+          type: array
+          # `$dynamicRef` is a JSON Schema 2020-12 dynamic referencing keyword
+          # adopted by 3.1; 3.0 only knows `$ref`, so this is a spec violation.
+          items:
+            $dynamicRef: '#node'

--- a/spec/data/openapi_3_1/dynamic_ref_31.yaml
+++ b/spec/data/openapi_3_1/dynamic_ref_31.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: Tree API
+  version: '1.0'
+paths:
+  /trees:
+    get:
+      summary: Fetch a tree
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        children:
+          type: array
+          # `$dynamicRef` is legitimate under 3.1 (JSON Schema 2020-12), so no
+          # violation is expected here.
+          items:
+            $dynamicRef: '#node'

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -184,4 +184,18 @@ RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
       expect_clean('const_31.yaml')
     end
   end
+
+  describe '$dynamicRef (JSON Schema 2020-12 referencing new in 3.1)' do
+    it 'warns on the version-mismatched document under :warn' do
+      expect_mismatch_warns('dynamic_ref_30.yaml', [:dynamic_ref_in30])
+    end
+
+    it 'raises SpecViolationError on the version-mismatched document under :raise' do
+      expect_mismatch_raises('dynamic_ref_30.yaml', [:dynamic_ref_in30])
+    end
+
+    it 'stays clean on the correctly-versioned document' do
+      expect_clean('dynamic_ref_31.yaml')
+    end
+  end
 end

--- a/spec/openapi_parser/spec_validator/rules/dynamic_ref_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/dynamic_ref_in_30_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe 'OpenAPIParser::SpecValidator::Rules::DynamicRefIn30' do
+  def base_doc(openapi_version_string, sample_schema)
+    {
+      'openapi' => openapi_version_string,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Sample' => sample_schema } },
+    }
+  end
+
+  def doc_with_dynamic_ref(openapi_version_string)
+    raw = base_doc(openapi_version_string, { '$dynamicRef' => '#meta' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_dynamic_ref(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def run_rule_for(root)
+    OpenAPIParser::SpecValidator::Rules::DynamicRefIn30.new(root.openapi_version).check(root)
+  end
+
+  context 'with a 3.1 document using $dynamicRef' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.1 document without $dynamicRef' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.0 document using $dynamicRef' do
+    it 'reports one violation pointing at the offending schema'
+  end
+
+  context 'with a 3.0 document without $dynamicRef' do
+    it 'reports no violation'
+  end
+
+  context 'with an :unknown version document' do
+    it 'reports no violation (rule skipped)'
+  end
+end

--- a/spec/openapi_parser/spec_validator/rules/dynamic_ref_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/dynamic_ref_in_30_spec.rb
@@ -25,22 +25,40 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::DynamicRefIn30' do
   end
 
   context 'with a 3.1 document using $dynamicRef' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_with_dynamic_ref('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.1 document without $dynamicRef' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_without_dynamic_ref('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.0 document using $dynamicRef' do
-    it 'reports one violation pointing at the offending schema'
+    it 'reports one violation pointing at the offending schema' do
+      root = doc_with_dynamic_ref('3.0.0')
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.rule_name).to eq :dynamic_ref_in30
+    end
   end
 
   context 'with a 3.0 document without $dynamicRef' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_without_dynamic_ref('3.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with an :unknown version document' do
-    it 'reports no violation (rule skipped)'
+    it 'reports no violation (rule skipped)' do
+      root = doc_with_dynamic_ref('4.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 end


### PR DESCRIPTION
Continuing the OpenAPI 3.1 work from #152.

OpenAPI 3.1 adopts JSON Schema 2020-12, which brings the `$dynamicRef` referencing mechanism.
3.0 only knows `$ref`.

This PR adds detection of that version mismatch.
A 3.0 document using `$dynamicRef` is relying on a keyword its declared version does not define, and `SpecValidator` should be able to say so.

### SpecValidator rule

`DynamicRefIn30` reports a violation for each schema in a 3.0 document that uses `$dynamicRef`:

```ruby
OpenAPIParser.load(
  'spec.yaml',
  strict_specification_version: :warn,
)
# [DynamicRefIn30] #/components/schemas/Node — `$dynamicRef` is a 3.1 addition (from JSON Schema 2020-12); 3.0 only knows `$ref`
```

Detection inspects `raw_schema` key presence,
so it fires regardless of whether the referenced anchor exists.

### Scope

This PR does not make `$dynamicRef` resolvable.
`$dynamicRef` has to branch its reference dynamically while the schema is being evaluated, which likely means redesigning `SchemaValidator` in this gem.
Resolving it is a TODO beyond this series of PRs.
