### PR TITLE
Support contentSchema for OpenAPI 3.1 schemas (parse + ContentSchemaIn30 rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@
   * `ConstIn30`: detect `const` usage in 3.0 documents (3.1 addition)
   * `DynamicRefIn30`: detect `$dynamicRef` usage in 3.0 documents (3.1 addition)
   * `DynamicAnchorIn30`: detect `$dynamicAnchor` usage in 3.0 documents (3.1 addition)
+  * `ContentSchemaIn30`: detect `contentSchema` usage in 3.0 documents (3.1 addition)
 * support 3.1-style numeric `exclusiveMinimum` / `exclusiveMaximum` in value validation (standalone bound, not a Boolean modifier on `minimum` / `maximum`)
 * support `type: "null"` (3.1 primitive) in value validation
 * support root-level `webhooks` (OpenAPI 3.1) in the parse layer
 * support `const` (OpenAPI 3.1) with exact-equality value validation
+* support `contentSchema` (OpenAPI 3.1) in the parse layer
 
 ## 2.3.1 (2025-11-14)
 * add optional date coercion with behavior matching existing datetime coercion

--- a/lib/openapi_parser/schemas/schema.rb
+++ b/lib/openapi_parser/schemas/schema.rb
@@ -103,6 +103,10 @@ module OpenAPIParser::Schemas
     #   @return [Array<Schema>, nil] tuple-style positional schemas (OpenAPI 3.1+)
     openapi_attr_list_object :prefix_items, Schema, reference: true, schema_key: :prefixItems
 
+    # @!attribute [r] content_schema
+    #   @return [Schema, nil] schema describing the content payload (OpenAPI 3.1+)
+    openapi_attr_object :content_schema, Schema, reference: true, schema_key: :contentSchema
+
     # @!attribute [r] properties
     #   @return [Hash{String => Schema}, nil]
     openapi_attr_hash_object :properties, Schema, reference: true

--- a/lib/openapi_parser/spec_validator.rb
+++ b/lib/openapi_parser/spec_validator.rb
@@ -14,6 +14,7 @@ require_relative 'spec_validator/rules/webhooks_in_30'
 require_relative 'spec_validator/rules/const_in_30'
 require_relative 'spec_validator/rules/dynamic_ref_in_30'
 require_relative 'spec_validator/rules/dynamic_anchor_in_30'
+require_relative 'spec_validator/rules/content_schema_in_30'
 
 module OpenAPIParser
   class SpecViolationError < OpenAPIError
@@ -75,6 +76,7 @@ module OpenAPIParser
           Rules::ConstIn30,
           Rules::DynamicRefIn30,
           Rules::DynamicAnchorIn30,
+          Rules::ContentSchemaIn30,
         ]
       end
   end

--- a/lib/openapi_parser/spec_validator/rules/content_schema_in_30.rb
+++ b/lib/openapi_parser/spec_validator/rules/content_schema_in_30.rb
@@ -1,0 +1,25 @@
+module OpenAPIParser
+  class SpecValidator
+    module Rules
+      # `contentSchema` is a JSON Schema 2020-12 annotation adopted by 3.1.
+      # The parse layer accepts it permissively; this rule reports the
+      # version mismatch on 3.0 documents.
+      class ContentSchemaIn30 < Rule
+        def check(root)
+          return [] unless version == :v3_0
+
+          violations = []
+          each_schema(root) do |schema|
+            next unless schema.raw_schema.is_a?(Hash) && schema.raw_schema.key?('contentSchema')
+
+            violations << violation(
+              path: schema.object_reference,
+              message: '`contentSchema` is a 3.1 addition (from JSON Schema 2020-12); 3.0 has no equivalent',
+            )
+          end
+          violations
+        end
+      end
+    end
+  end
+end

--- a/sig/openapi_parser/spec_validator.rbs
+++ b/sig/openapi_parser/spec_validator.rbs
@@ -92,6 +92,10 @@ module OpenAPIParser
       class DynamicAnchorIn30 < Rule
         def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
       end
+
+      class ContentSchemaIn30 < Rule
+        def check: (OpenAPIParser::Schemas::OpenAPI root) -> Array[SpecValidator::SpecViolation]
+      end
     end
   end
 

--- a/spec/data/openapi_3_1/content_schema_30.yaml
+++ b/spec/data/openapi_3_1/content_schema_30.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Document Upload API
+  version: '1.0'
+paths:
+  /documents:
+    post:
+      summary: Upload a document
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Attachment'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Attachment:
+      type: string
+      # `contentSchema` is a JSON Schema 2020-12 annotation adopted by 3.1;
+      # 3.0 has no equivalent, so its use on a 3.0 document is a spec
+      # violation.
+      contentSchema:
+        type: object
+        properties:
+          name:
+            type: string

--- a/spec/data/openapi_3_1/content_schema_31.yaml
+++ b/spec/data/openapi_3_1/content_schema_31.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Document Upload API
+  version: '1.0'
+paths:
+  /documents:
+    post:
+      summary: Upload a document
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Attachment'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Attachment:
+      type: string
+      # `contentSchema` is legitimate under 3.1 (JSON Schema 2020-12), so no
+      # violation is expected here.
+      contentSchema:
+        type: object
+        properties:
+          name:
+            type: string

--- a/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
+++ b/spec/openapi_parser/spec_validator/integration_3_1_spec.rb
@@ -240,4 +240,18 @@ RSpec.describe 'OpenAPIParser 3.1 spec validator (integration)' do
       expect_clean('dynamic_anchor_31.yaml')
     end
   end
+
+  describe 'contentSchema (JSON Schema 2020-12 annotation new in 3.1)' do
+    it 'warns on the version-mismatched document under :warn' do
+      expect_mismatch_warns('content_schema_30.yaml', [:content_schema_in30])
+    end
+
+    it 'raises SpecViolationError on the version-mismatched document under :raise' do
+      expect_mismatch_raises('content_schema_30.yaml', [:content_schema_in30])
+    end
+
+    it 'stays clean on the correctly-versioned document' do
+      expect_clean('content_schema_31.yaml')
+    end
+  end
 end

--- a/spec/openapi_parser/spec_validator/rules/content_schema_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/content_schema_in_30_spec.rb
@@ -31,22 +31,40 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ContentSchemaIn30' do
   end
 
   context 'with a 3.1 document using contentSchema' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_with_content_schema('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.1 document without contentSchema' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_without_content_schema('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with a 3.0 document using contentSchema' do
-    it 'reports one violation pointing at the offending schema'
+    it 'reports one violation pointing at the offending schema' do
+      root = doc_with_content_schema('3.0.0')
+      violations = run_rule_for(root)
+      expect(violations.size).to eq 1
+      expect(violations.first.path).to eq '#/components/schemas/Sample'
+      expect(violations.first.rule_name).to eq :content_schema_in30
+    end
   end
 
   context 'with a 3.0 document without contentSchema' do
-    it 'reports no violation'
+    it 'reports no violation' do
+      root = doc_without_content_schema('3.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 
   context 'with an :unknown version document' do
-    it 'reports no violation (rule skipped)'
+    it 'reports no violation (rule skipped)' do
+      root = doc_with_content_schema('4.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
   end
 end

--- a/spec/openapi_parser/spec_validator/rules/content_schema_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/content_schema_in_30_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../../../spec_helper'
+
+RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ContentSchemaIn30' do
+  def base_doc(openapi_version_string, sample_schema)
+    {
+      'openapi' => openapi_version_string,
+      'info' => { 'title' => 'test', 'version' => '1.0' },
+      'paths' => {},
+      'components' => { 'schemas' => { 'Sample' => sample_schema } },
+    }
+  end
+
+  def doc_with_content_schema(openapi_version_string)
+    raw = base_doc(
+      openapi_version_string,
+      {
+        'type' => 'string',
+        'contentSchema' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'integer' } } },
+      },
+    )
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_content_schema(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def run_rule_for(root)
+    OpenAPIParser::SpecValidator::Rules::ContentSchemaIn30.new(root.openapi_version).check(root)
+  end
+
+  context 'with a 3.1 document using contentSchema' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.1 document without contentSchema' do
+    it 'reports no violation'
+  end
+
+  context 'with a 3.0 document using contentSchema' do
+    it 'reports one violation pointing at the offending schema'
+  end
+
+  context 'with a 3.0 document without contentSchema' do
+    it 'reports no violation'
+  end
+
+  context 'with an :unknown version document' do
+    it 'reports no violation (rule skipped)'
+  end
+end


### PR DESCRIPTION
Continuing the OpenAPI 3.1 work from #152.

OpenAPI 3.1 adopts JSON Schema 2020-12, which brings the `contentSchema` annotation.
It attaches a schema to the decoded payload of a string described by `contentMediaType` / `contentEncoding`.
3.0 has no keyword for this.

This PR adds parse support and version-mismatch detection.
It completes the trio started in #204 (`contentMediaType`) and continued with `contentEncoding`.

### Parse layer

`contentSchema` is parsed as a nested `Schema` (or `Reference`) and exposed as `content_schema`,
following the existing snake_case naming for object attributes (`all_of`, `additional_properties`, `prefix_items`):

```ruby
schema.content_schema       # => OpenAPIParser::Schemas::Schema
schema.content_schema.type  # => "object"
```

Following the permissive-parse strategy agreed in #152,
the parse layer accepts `contentSchema` regardless of the declared OpenAPI version.

`contentSchema` is an annotation: it describes the decoded payload rather than constraining the string itself,
so there is no runtime validation to add here.
Validating the decoded payload would first require decoding it per `contentEncoding`,
which is out of scope for this series.

### SpecValidator rule

`ContentSchemaIn30` reports a violation for each schema in a 3.0 document that uses `contentSchema`:

```ruby
OpenAPIParser.load(
  'spec.yaml',
  strict_specification_version: :warn,
)
# [ContentSchemaIn30] #/components/schemas/Attachment — `contentSchema` is a 3.1 addition (from JSON Schema 2020-12); 3.0 has no equivalent
```

Detection inspects `raw_schema` key presence,
so it fires whatever the nested schema contains.
