### PR TITLE
Align early SpecValidator rule specs with the later rule spec layout (spec only)

### DIFF
--- a/spec/openapi_parser/schema_validator_spec.rb
+++ b/spec/openapi_parser/schema_validator_spec.rb
@@ -1047,4 +1047,65 @@ RSpec.describe OpenAPIParser::SchemaValidator do
       end
     end
   end
+
+  describe 'type: "null" semantic (3.1)' do
+    let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
+    let(:schema) do
+      raw = {
+        'openapi' => '3.1.0',
+        'info' => { 'title' => 'test', 'version' => '1.0' },
+        'paths' => {},
+        'components' => { 'schemas' => { 'Nullable' => { 'type' => 'null' } } },
+      }
+      OpenAPIParser.parse(raw, strict_reference_validation: false).components.schemas['Nullable']
+    end
+
+    context 'when value is nil' do
+      it 'passes validation without nullable' do
+        result = OpenAPIParser::SchemaValidator.validate(nil, schema, options)
+        expect(result).to eq nil
+      end
+    end
+
+    context 'when value is not nil' do
+      it 'raises a type-mismatch error' do
+        expect do
+          OpenAPIParser::SchemaValidator.validate('not nil', schema, options)
+        end.to raise_error(OpenAPIParser::ValidateError)
+      end
+    end
+  end
+
+  describe 'array-form type semantic (3.1)' do
+    let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
+    let(:schema) do
+      raw = {
+        'openapi' => '3.1.0',
+        'info' => { 'title' => 'test', 'version' => '1.0' },
+        'paths' => {},
+        'components' => { 'schemas' => { 'NullableString' => { 'type' => ['string', 'null'] } } },
+      }
+      OpenAPIParser.parse(raw, strict_reference_validation: false).components.schemas['NullableString']
+    end
+
+    context 'when value is nil and array contains "null"' do
+      it 'passes validation' do
+        expect(OpenAPIParser::SchemaValidator.validate(nil, schema, options)).to eq nil
+      end
+    end
+
+    context 'when value matches one of the listed types' do
+      it 'passes validation' do
+        expect(OpenAPIParser::SchemaValidator.validate('hello', schema, options)).to eq 'hello'
+      end
+    end
+
+    context 'when value matches no listed type' do
+      it 'raises a type-mismatch error' do
+        expect do
+          OpenAPIParser::SchemaValidator.validate(42, schema, options)
+        end.to raise_error(OpenAPIParser::ValidateError)
+      end
+    end
+  end
 end

--- a/spec/openapi_parser/spec_validator/rules/example_singular_deprecation_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/example_singular_deprecation_spec.rb
@@ -1,13 +1,27 @@
 require_relative '../../../spec_helper'
 
 RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ExampleSingularDeprecation' do
-  def schema_with_example(openapi_version_string, schema_payload)
-    raw = {
+  def base_doc(openapi_version_string, sample_schema)
+    {
       'openapi' => openapi_version_string,
       'info' => { 'title' => 'test', 'version' => '1.0' },
       'paths' => {},
-      'components' => { 'schemas' => { 'Sample' => schema_payload } },
+      'components' => { 'schemas' => { 'Sample' => sample_schema } },
     }
+  end
+
+  def doc_with_example(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string', 'example' => 'sample' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_example(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_with_examples_array(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string', 'examples' => ['sample'] })
     OpenAPIParser.parse(raw, strict_reference_validation: false)
   end
 
@@ -17,14 +31,21 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ExampleSingularDeprecation'
 
   context 'with a 3.0 document using singular example on a Schema' do
     it 'reports no violation' do
-      root = schema_with_example('3.0.0', { 'type' => 'string', 'example' => 'sample' })
+      root = doc_with_example('3.0.0')
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.0 document without singular example' do
+    it 'reports no violation' do
+      root = doc_without_example('3.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
   context 'with a 3.1 document using singular example on a Schema' do
     it 'reports one violation pointing at the offending schema' do
-      root = schema_with_example('3.1.0', { 'type' => 'string', 'example' => 'sample' })
+      root = doc_with_example('3.1.0')
       violations = run_rule_for(root)
       expect(violations.size).to eq 1
       expect(violations.first.path).to eq '#/components/schemas/Sample'
@@ -33,23 +54,23 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::ExampleSingularDeprecation'
     end
   end
 
-  context 'with a 3.1 document that does not use singular example' do
+  context 'with a 3.1 document without singular example' do
     it 'reports no violation' do
-      root = schema_with_example('3.1.0', { 'type' => 'string' })
+      root = doc_without_example('3.1.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
   context 'with a 3.1 document using the examples array (correct 3.1 form)' do
     it 'reports no violation' do
-      root = schema_with_example('3.1.0', { 'type' => 'string', 'examples' => ['sample'] })
+      root = doc_with_examples_array('3.1.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
   context 'with an :unknown version document' do
     it 'reports no violation (rule skipped)' do
-      root = schema_with_example('4.0.0', { 'type' => 'string', 'example' => 'sample' })
+      root = doc_with_example('4.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end

--- a/spec/openapi_parser/spec_validator/rules/path_items_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/path_items_in_30_spec.rb
@@ -1,19 +1,30 @@
 require_relative '../../../spec_helper'
 
 RSpec.describe 'OpenAPIParser::SpecValidator::Rules::PathItemsIn30' do
-  def doc_with_path_items(openapi_version_string, include_path_items: true)
-    components = { 'schemas' => {} }
-    if include_path_items
-      components['pathItems'] = {
-        'sample' => { 'get' => { 'responses' => { '200' => { 'description' => 'ok' } } } },
-      }
-    end
-    raw = {
+  def base_doc(openapi_version_string, components)
+    {
       'openapi' => openapi_version_string,
       'info' => { 'title' => 'test', 'version' => '1.0' },
       'paths' => {},
       'components' => components,
     }
+  end
+
+  def doc_with_path_items(openapi_version_string)
+    raw = base_doc(
+      openapi_version_string,
+      {
+        'schemas' => {},
+        'pathItems' => {
+          'sample' => { 'get' => { 'responses' => { '200' => { 'description' => 'ok' } } } },
+        },
+      },
+    )
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_path_items(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'schemas' => {} })
     OpenAPIParser.parse(raw, strict_reference_validation: false)
   end
 
@@ -24,6 +35,13 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::PathItemsIn30' do
   context 'with a 3.1 document using components.pathItems' do
     it 'reports no violation' do
       root = doc_with_path_items('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.1 document without components.pathItems' do
+    it 'reports no violation' do
+      root = doc_without_path_items('3.1.0')
       expect(run_rule_for(root)).to eq []
     end
   end
@@ -40,12 +58,12 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::PathItemsIn30' do
 
   context 'with a 3.0 document without components.pathItems' do
     it 'reports no violation' do
-      root = doc_with_path_items('3.0.0', include_path_items: false)
+      root = doc_without_path_items('3.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
-  context 'with an :unknown version document using components.pathItems' do
+  context 'with an :unknown version document' do
     it 'reports no violation (rule skipped)' do
       root = doc_with_path_items('4.0.0')
       expect(run_rule_for(root)).to eq []

--- a/spec/openapi_parser/spec_validator/rules/type_array_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_array_in_30_spec.rb
@@ -46,36 +46,3 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeArrayIn30' do
     end
   end
 end
-
-RSpec.describe 'runtime: type as Array semantic in 3.1' do
-  let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
-  let(:schema) do
-    raw = {
-      'openapi' => '3.1.0',
-      'info' => { 'title' => 'test', 'version' => '1.0' },
-      'paths' => {},
-      'components' => { 'schemas' => { 'NullableString' => { 'type' => ['string', 'null'] } } },
-    }
-    OpenAPIParser.parse(raw, strict_reference_validation: false).components.schemas['NullableString']
-  end
-
-  context 'when value is nil and array contains "null"' do
-    it 'passes validation' do
-      expect(OpenAPIParser::SchemaValidator.validate(nil, schema, options)).to eq nil
-    end
-  end
-
-  context 'when value matches one of the listed types' do
-    it 'passes validation' do
-      expect(OpenAPIParser::SchemaValidator.validate('hello', schema, options)).to eq 'hello'
-    end
-  end
-
-  context 'when value matches no listed type' do
-    it 'raises a type-mismatch error' do
-      expect do
-        OpenAPIParser::SchemaValidator.validate(42, schema, options)
-      end.to raise_error(OpenAPIParser::ValidateError)
-    end
-  end
-end

--- a/spec/openapi_parser/spec_validator/rules/type_array_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_array_in_30_spec.rb
@@ -1,13 +1,22 @@
 require_relative '../../../spec_helper'
 
 RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeArrayIn30' do
-  def schema_with_type_array(openapi_version_string, types)
-    raw = {
+  def base_doc(openapi_version_string, sample_schema)
+    {
       'openapi' => openapi_version_string,
       'info' => { 'title' => 'test', 'version' => '1.0' },
       'paths' => {},
-      'components' => { 'schemas' => { 'Sample' => { 'type' => types } } },
+      'components' => { 'schemas' => { 'Sample' => sample_schema } },
     }
+  end
+
+  def doc_with_type_array(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => ['string', 'null'] })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_type_array(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string' })
     OpenAPIParser.parse(raw, strict_reference_validation: false)
   end
 
@@ -17,14 +26,21 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeArrayIn30' do
 
   context 'with a 3.1 document using type as Array' do
     it 'reports no violation' do
-      root = schema_with_type_array('3.1.0', ['string', 'null'])
+      root = doc_with_type_array('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.1 document using type as a plain string' do
+    it 'reports no violation' do
+      root = doc_without_type_array('3.1.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
   context 'with a 3.0 document using type as Array' do
     it 'reports one violation pointing at the offending schema' do
-      root = schema_with_type_array('3.0.0', ['string', 'null'])
+      root = doc_with_type_array('3.0.0')
       violations = run_rule_for(root)
       expect(violations.size).to eq 1
       expect(violations.first.path).to eq '#/components/schemas/Sample'
@@ -32,16 +48,16 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeArrayIn30' do
     end
   end
 
-  context 'with a 3.0 document using type as plain string' do
+  context 'with a 3.0 document using type as a plain string' do
     it 'reports no violation' do
-      root = schema_with_type_array('3.0.0', 'string')
+      root = doc_without_type_array('3.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
-  context 'with an :unknown version document using type as Array' do
+  context 'with an :unknown version document' do
     it 'reports no violation (rule skipped)' do
-      root = schema_with_type_array('4.0.0', ['string', 'null'])
+      root = doc_with_type_array('4.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end

--- a/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
@@ -52,31 +52,3 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
     end
   end
 end
-
-RSpec.describe 'runtime: type: "null" semantic' do
-  let(:options) { ::OpenAPIParser::SchemaValidator::Options.new }
-  let(:schema) do
-    raw = {
-      'openapi' => '3.1.0',
-      'info' => { 'title' => 'test', 'version' => '1.0' },
-      'paths' => {},
-      'components' => { 'schemas' => { 'Nullable' => { 'type' => 'null' } } },
-    }
-    OpenAPIParser.parse(raw, strict_reference_validation: false).components.schemas['Nullable']
-  end
-
-  context 'when value is nil' do
-    it 'passes validation without nullable' do
-      result = OpenAPIParser::SchemaValidator.validate(nil, schema, options)
-      expect(result).to eq nil
-    end
-  end
-
-  context 'when value is not nil' do
-    it 'raises a type-mismatch error' do
-      expect do
-        OpenAPIParser::SchemaValidator.validate('not nil', schema, options)
-      end.to raise_error(OpenAPIParser::ValidateError)
-    end
-  end
-end

--- a/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
+++ b/spec/openapi_parser/spec_validator/rules/type_null_in_30_spec.rb
@@ -1,13 +1,22 @@
 require_relative '../../../spec_helper'
 
 RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
-  def schema_with_type_null(openapi_version_string)
-    raw = {
+  def base_doc(openapi_version_string, sample_schema)
+    {
       'openapi' => openapi_version_string,
       'info' => { 'title' => 'test', 'version' => '1.0' },
       'paths' => {},
-      'components' => { 'schemas' => { 'Sample' => { 'type' => 'null' } } },
+      'components' => { 'schemas' => { 'Sample' => sample_schema } },
     }
+  end
+
+  def doc_with_type_null(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'null' })
+    OpenAPIParser.parse(raw, strict_reference_validation: false)
+  end
+
+  def doc_without_type_null(openapi_version_string)
+    raw = base_doc(openapi_version_string, { 'type' => 'string' })
     OpenAPIParser.parse(raw, strict_reference_validation: false)
   end
 
@@ -17,14 +26,21 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
 
   context 'with a 3.1 document using type: "null"' do
     it 'reports no violation' do
-      root = schema_with_type_null('3.1.0')
+      root = doc_with_type_null('3.1.0')
+      expect(run_rule_for(root)).to eq []
+    end
+  end
+
+  context 'with a 3.1 document without type: "null"' do
+    it 'reports no violation' do
+      root = doc_without_type_null('3.1.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
   context 'with a 3.0 document using type: "null"' do
     it 'reports one violation pointing at the offending schema' do
-      root = schema_with_type_null('3.0.0')
+      root = doc_with_type_null('3.0.0')
       violations = run_rule_for(root)
       expect(violations.size).to eq 1
       expect(violations.first.path).to eq '#/components/schemas/Sample'
@@ -32,22 +48,16 @@ RSpec.describe 'OpenAPIParser::SpecValidator::Rules::TypeNullIn30' do
     end
   end
 
-  context 'with a 3.0 document using a normal type' do
+  context 'with a 3.0 document without type: "null"' do
     it 'reports no violation' do
-      raw = {
-        'openapi' => '3.0.0',
-        'info' => { 'title' => 'test', 'version' => '1.0' },
-        'paths' => {},
-        'components' => { 'schemas' => { 'Sample' => { 'type' => 'string' } } },
-      }
-      root = OpenAPIParser.parse(raw, strict_reference_validation: false)
+      root = doc_without_type_null('3.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end
 
-  context 'with an :unknown version document using type: "null"' do
+  context 'with an :unknown version document' do
     it 'reports no violation (rule skipped)' do
-      root = schema_with_type_null('4.0.0')
+      root = doc_with_type_null('4.0.0')
       expect(run_rule_for(root)).to eq []
     end
   end


### PR DESCRIPTION
Spec-only follow-up to the SpecValidator series from #152.
No library code changes.

The rule specs added later in the series (#199 onwards) settled on a common layout:

- a `base_doc` helper that builds the document skeleton,
  with `doc_with_<feature>` / `doc_without_<feature>` helpers on top of it
  instead of one helper taking a flag or a payload argument
- one example for each version x usage combination
  (3.1 with / 3.1 without / 3.0 with / 3.0 without / unknown version)
- runtime behaviour specs kept next to the other `SchemaValidator` specs,
  not inside the rule spec

The earlier rule specs predate that layout.
This PR brings four of them in line so the rule specs read the same way throughout.

### Runtime specs moved out of rule specs

`type_null_in_30_spec.rb` and `type_array_in_30_spec.rb` each carried a second top-level `RSpec.describe`
covering the runtime behaviour of `type: "null"` and array-form `type`.
Those examples move verbatim into `schema_validator_spec.rb`,
nested under the existing top-level describe next to the `const` runtime examples from #200.
This matches where #192 (`integer_validator_spec.rb`) and #202 (`array_validator_spec.rb`) put theirs.

### Helpers split, missing combinations added

- `PathItemsIn30`: the `include_path_items:` boolean flag becomes `doc_with_path_items` / `doc_without_path_items`.
  Adds the "3.1 document without `components.pathItems`" example.
- `TypeNullIn30` / `TypeArrayIn30`: the single parameterised helper becomes `doc_with_<feature>` / `doc_without_<feature>`.
  Adds the "3.1 document without the feature" example to each.
- `ExampleSingularDeprecation`: the payload-taking helper becomes
  `doc_with_example` / `doc_without_example` / `doc_with_examples_array`.
  Adds the "3.0 document without singular `example`" example.

The `ExclusiveMinimum` / `ExclusiveMaximum` / `NullableDeprecation` specs are left as they are.
They already enumerate more combinations than the common layout
(3.0-style vs 3.1-style form, `true` vs `false`), and reshaping them would only shuffle lines.

Each commit passes `rake` (rspec + steep) on its own.
This PR touches none of the files changed by the two open `contentEncoding` / `contentSchema` PRs,
so it can land in any order relative to them.
